### PR TITLE
Fix Hide legend only when data given in single series format - Fixed #8

### DIFF
--- a/app/assets/javascripts/chartkick.js
+++ b/app/assets/javascripts/chartkick.js
@@ -97,7 +97,10 @@
 
       // hide legend
       if (series.length === 1) {
-        hideLegend(options);
+		// hide legend only if no name is specified
+		if (typeof series[0].name === 'undefined') {
+			hideLegend(options);
+		}       
       }
 
       // min


### PR DESCRIPTION
Hey,
First of all sorry because I'm not sure how to add this pull request directly to the issue.

I guess this should fix the issue #8:

The legend will only be displayed for a single serie if the :name symbol is specified in the data.

Thomas
