### PR TITLE
Option to display the js in a content_for block

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,16 @@ You can pass options directly to the charting library with:
 <%= line_chart User.group_by_day(:created_at).count, :library => {:backgroundColor => "#eee"} %>
 ```
 
+You can also pass a content_for option, this will put the initializing javascripts in the content_block you specify:
+
+```erb
+<%= line_chart User.group_by_day(:created_at).count, :content_for => :js_initialization %>
+```
+Then, in your layout:
+```erb
+<%= content_for :js_initialization %>
+```
+
 ### Data
 
 Pass data as a Hash or Array
@@ -108,7 +118,7 @@ Add this line to your application's Gemfile:
 gem "chartkick"
 ```
 
-And add the javascript files to your views.  These files must be included **before** the helper methods.
+And add the javascript files to your views.  These files must be included **before** the helper methods, unless using the content_for option to the helper. 
 
 For Google Charts, use:
 

--- a/lib/chartkick/helper.rb
+++ b/lib/chartkick/helper.rb
@@ -28,10 +28,17 @@ module Chartkick
 <div id="#{ERB::Util.html_escape(element_id)}" style="height: #{ERB::Util.html_escape(height)}; text-align: center; color: #999; line-height: #{ERB::Util.html_escape(height)}; font-size: 14px; font-family: 'Lucida Grande', 'Lucida Sans Unicode', Verdana, Arial, Helvetica, sans-serif;">
   Loading...
 </div>
+HTML
+     js = <<JS
 <script type="text/javascript">
   new Chartkick.#{klass}(#{element_id.to_json}, #{data_source.to_json}, #{options.to_json});
 </script>
-HTML
+JS
+      if options[:content_for]
+        content_for(options[:content_for]) { js.respond_to?(:html_safe) ? js.html_safe : js }
+      else
+        html += js
+      end
 
       html.respond_to?(:html_safe) ? html.html_safe : html
     end


### PR DESCRIPTION
Added a new option to the helper: content_for if present, it outputs the js of the chart in that block, instead of puting it right under the html. Allows to include the chartkick and highcharts/googlecharts in the bottom of the page.
