### PR TITLE
allow user to pass ajaxOptions directly to ajax request

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,12 @@ You can pass options directly to the charting library with:
 <%= line_chart data, library: {backgroundColor: "#eee"} %>
 ```
 
+For remote data sources, you can pass options to the $.ajax call with:
+
+```erb
+<%= line_chart data, ajaxOptions: {<ajax options>} %>
+```
+
 See the documentation for [Google Charts](https://developers.google.com/chart/interactive/docs/gallery) and [Highcharts](http://api.highcharts.com/highcharts) for more info.
 
 ### Global Options

--- a/README.md
+++ b/README.md
@@ -269,6 +269,16 @@ To specify a language for Google Charts, add:
 
 **before** the javascript files.
 
+### Limiting the Number of Simultaneous Ajax Requests
+
+To limit the number of ajax requests made simultaneously, you could include an extension to jquery ajax that provides this feature (see https://gist.github.com/dontfidget/1ad9ab33971b64fe6fef for an example) and then set the global chartkick options to enable this feature for your chartkick remote data requests:
+
+```ruby
+Chartkick.options = {
+  ajaxOptions: {queue: true, queueMaxConcurrency: 2} 
+}
+```
+
 ## No Ruby? No Problem
 
 Check out [chartkick.js](https://github.com/ankane/chartkick.js)

--- a/app/assets/javascripts/chartkick.js
+++ b/app/assets/javascripts/chartkick.js
@@ -152,9 +152,9 @@
     element.style.color = "#ff0000";
   }
 
-  function getJSON(element, url, success) {
+  function getJSON(element, url, options, success) {
     var $ = window.jQuery || window.Zepto || window.$;
-    $.ajax({
+    $.ajax($.extend({}, options, {
       dataType: "json",
       url: url,
       success: success,
@@ -162,7 +162,7 @@
         var message = (typeof errorThrown === "string") ? errorThrown : errorThrown.message;
         chartError(element, message);
       }
-    });
+    }));
   }
 
   function errorCatcher(chart, callback) {
@@ -176,7 +176,7 @@
 
   function fetchDataSource(chart, callback) {
     if (typeof chart.dataSource === "string") {
-      getJSON(chart.element, chart.dataSource, function (data, textStatus, jqXHR) {
+      getJSON(chart.element, chart.dataSource, chart.options.ajaxOptions, function (data, textStatus, jqXHR) {
         chart.data = data;
         errorCatcher(chart, callback);
       });


### PR DESCRIPTION
Here's a request that allows the field ajaxOptions to be passed to the ajax request.  Please let me know if you might consider it.  I'm using this with with chartkick-remote and this gist https://gist.github.com/dontfidget/1ad9ab33971b64fe6fef, which allows me to limit the number of concurrent remote requests.

My controller then has this code:

```
  include Chartkick::Remote
  chartkick_remote ajaxOptions: {queue: true, queueMaxConcurrency: 2}

```

I've also taken your suggestion and made remote requests the default behavior for views on controllers that call `chartkick_remote`.  Definitely looks better. Thanks.
