### PR TITLE
sort automatically generated multiple series list by name

### DIFF
--- a/lib/chartkick.rb
+++ b/lib/chartkick.rb
@@ -16,7 +16,7 @@ end
 module Enumerable
   def chart_json
     if is_a?(Hash) and (key = keys.first) and key.is_a?(Array) and key.size == 2
-      group_by{|k, v| k[0] }.map do |name, data|
+      group_by{|k, v| k[0] }.sort.map do |name, data|
         {name: name, data: data.map{|k, v| [k[1], v] }}
       end
     else


### PR DESCRIPTION
The automatically generated hashes with the name and description keys are not sorted so the output order is non deterministic.  This change just calls sort so that they are deterministic (and happen to be sorted by name).  This is useful for things like multiple pie charts on a page, where you would like the categories to retain the same color through multiple charts.

Now maybe I shouldn't be depending on this code which is a rather unfortunate extension -- not that I have a better solution -- but I've found it easier just to comply with it.
