### PR TITLE
Set series options available on column chart

### DIFF
--- a/app/assets/javascripts/chartkick.js
+++ b/app/assets/javascripts/chartkick.js
@@ -375,10 +375,8 @@
             d.push(rows[categories[j]][i] || 0);
           }
 
-          newSeries.push({
-            name: series[i].name,
-            data: d
-          });
+          series[i]['data'] = d
+          newSeries.push(series[i]);
         }
         options.series = newSeries;
 

--- a/app/assets/javascripts/chartkick.js
+++ b/app/assets/javascripts/chartkick.js
@@ -375,7 +375,7 @@
             d.push(rows[categories[j]][i] || 0);
           }
 
-          series[i]['data'] = d
+          series[i].data = d
           newSeries.push(series[i]);
         }
         options.series = newSeries;


### PR DESCRIPTION
This code allows the user to add options on HighChart ColumnChart series (http://api.highcharts.com/highcharts#series), for example :

```
series: [
  {
    name: 'Serie 1',
    data: [1, 2, 3],
    yAxis: 0
  },
  {
    name: 'Serie 1',
    data: [1, 2, 3],
    yAxis: 1
  }
]
```

I've done it this way because it was the simplest way for me to add yAxis option on ColumnChart series.

Am I doing something wrong ? What do you think about it ?
