### PR TITLE
Show that JQuery is necessary for Highcharts to work

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ For Google Charts, use:
 If you prefer Highcharts, use:
 
 ```erb
-<%= javascript_include_tag "path/to/highcharts.js", "chartkick" %>
+<%= javascript_include_tag "path/to/jquery.js", "path/to/highcharts.js", "chartkick" %>
 ```
 
 ### For Rails 3.1+


### PR DESCRIPTION
In order for highcharts to work jquery must be included on the page. This pull request attempts to clarify this in the README.md.