### PR TITLE
Make instance checkers work over different contexts.

### DIFF
--- a/app/assets/javascripts/chartkick.js
+++ b/app/assets/javascripts/chartkick.js
@@ -22,8 +22,8 @@
 
 	isArray = Array.isArray || function(ary) { return toString.call(ary) === '[object Array]'; };
 
-  function isPlainObject(variable) {
-    return !isFunction(variable) && variable instanceof Object;
+	function isPlainObject(obj) {
+    return obj === Object(obj);
   }
 
   // https://github.com/madrobby/zepto/blob/master/src/zepto.js

--- a/app/assets/javascripts/chartkick.js
+++ b/app/assets/javascripts/chartkick.js
@@ -20,9 +20,7 @@
     return (typeof fn === 'function');
   }
 
-  function isFunction(variable) {
-    return variable instanceof Function;
-  }
+	isArray = Array.isArray || function(ary) { return toString.call(ary) === '[object Array]'; };
 
   function isPlainObject(variable) {
     return !isFunction(variable) && variable instanceof Object;

--- a/app/assets/javascripts/chartkick.js
+++ b/app/assets/javascripts/chartkick.js
@@ -20,7 +20,7 @@
     return (typeof fn === 'function');
   }
 
-	isArray = Array.isArray || function(ary) { return toString.call(ary) === '[object Array]'; };
+	isArray = Array.isArray || function(ary) { return Object.prototype.toString.call(ary) === '[object Array]'; };
 
 	function isPlainObject(obj) {
     return obj === Object(obj);

--- a/app/assets/javascripts/chartkick.js
+++ b/app/assets/javascripts/chartkick.js
@@ -16,8 +16,8 @@
 
   // helpers
 
-  function isArray(variable) {
-    return Object.prototype.toString.call(variable) === "[object Array]";
+	function isFunction(fn) {
+    return (typeof fn === 'function');
   }
 
   function isFunction(variable) {


### PR DESCRIPTION
The old form used `instanceof` which has the tricky side-effect of not working between different contexts—i.e. frames, windows, etc. Its a nasty difference and it has burned me in the past.
See [Mozilla's Explaination](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/instanceof) of it.
