### PR TITLE
Avoid protocol relative URLs if TLS/SSL available

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ And add the javascript files to your views.  These files must be included **befo
 For Google Charts, use:
 
 ```erb
-<%= javascript_include_tag "//www.google.com/jsapi", "chartkick" %>
+<%= javascript_include_tag "https://www.google.com/jsapi", "chartkick" %>
 ```
 
 If you prefer Highcharts, use:


### PR DESCRIPTION
> Now that SSL is encouraged for everyone and doesn’t have performance concerns, this technique is now an anti-pattern. If the asset you need is available on SSL, then always use the https:// asset. Allowing the snippet to request over HTTP opens the door for attacks like the recent Github Man-on-the-side attack. It’s always safe to request HTTPS assets even if your site is on HTTP, however the reverse is not true.

Source: http://www.paulirish.com/2010/the-protocol-relative-url/