### PR TITLE
number formating in charts, fixed #145

### DIFF
--- a/app/assets/javascripts/chartkick.js
+++ b/app/assets/javascripts/chartkick.js
@@ -128,26 +128,8 @@
         setStacked(options);
       }
       
-      //new: possible to overwrite legend options
-      //maybe better: take always opts options before default options.
-      if (opts.legend){
-        options.legend = opts.legend 
-      }
-      
       if (opts.colors) {
         options.colors = opts.colors;
-      }
-      
-      if (opts.chartArea){
-        options.chartArea = opts.chartArea
-      }
-      
-      if (opts.vAxis){
-        options.vAxis = merge(options.vAxis, opts.vAxis);
-        alert(JSON.stringify(options.vAxis))
-      }
-      if (opts.hAxis){
-        options.hAxis = merge(options.hAxis, opts.hAxis);
       }
 
       // merge library last

--- a/app/assets/javascripts/chartkick.js
+++ b/app/assets/javascripts/chartkick.js
@@ -10,10 +10,10 @@
 
 (function (window) {
   'use strict';
-
+  
   var config = window.Chartkick || {};
   var Chartkick, ISO8601_PATTERN, DECIMAL_SEPARATOR, adapters = [];
-
+  
   // helpers
 
   function isArray(variable) {
@@ -106,7 +106,7 @@
       var options = merge({}, defaultOptions);
       options = merge(options, chartOptions || {});
 
-      // hide legend
+       // hide legend
       // this is *not* an external option!
       if (opts.hideLegend) {
         hideLegend(options);
@@ -127,14 +127,31 @@
       if (opts.stacked) {
         setStacked(options);
       }
-
+      
+      //new: possible to overwrite legend options
+      //maybe better: take always opts options before default options.
+      if (opts.legend){
+        options.legend = opts.legend 
+      }
+      
       if (opts.colors) {
         options.colors = opts.colors;
+      }
+      
+      if (opts.chartArea){
+        options.chartArea = opts.chartArea
+      }
+      
+      if (opts.vAxis){
+        options.vAxis = merge(options.vAxis, opts.vAxis);
+        alert(JSON.stringify(options.vAxis))
+      }
+      if (opts.hAxis){
+        options.hAxis = merge(options.hAxis, opts.hAxis);
       }
 
       // merge library last
       options = merge(options, opts.library || {});
-
       return options;
     };
   }
@@ -556,7 +573,9 @@
         waitForLoaded(function () {
           var options = jsOptions(chart.data, chart.options);
           var data = createDataTable(chart.data, chart.options.discrete ? "string" : "datetime");
+          formatData(chart.options, data, chart.data.length)
           chart.chart = new google.visualization.LineChart(chart.element);
+          
           resize(function () {
             chart.chart.draw(data, options);
           });
@@ -575,12 +594,14 @@
             chartOptions.colors = chart.options.colors;
           }
           var options = merge(merge(defaultOptions, chartOptions), chart.options.library || {});
-
+          
           var data = new google.visualization.DataTable();
           data.addColumn("string", "");
           data.addColumn("number", "Value");
           data.addRows(chart.data);
-
+          // new: formatter for formatting values in pie chart 
+          formatData(chart.options, data, 1)
+          
           chart.chart = new google.visualization.PieChart(chart.element);
           resize(function () {
             chart.chart.draw(data, options);
@@ -592,6 +613,8 @@
         waitForLoaded(function () {
           var options = jsOptions(chart.data, chart.options);
           var data = createDataTable(chart.data, "string");
+          // new: formatter for formatting values in column chart 
+          formatData(chart.options, data, chart.data.length)
           chart.chart = new google.visualization.ColumnChart(chart.element);
           resize(function () {
             chart.chart.draw(data, options);
@@ -610,6 +633,9 @@
           };
           var options = jsOptionsFunc(defaultOptions, hideLegend, setBarMin, setBarMax, setStacked)(chart.data, chart.options, chartOptions);
           var data = createDataTable(chart.data, "string");
+          // new: formatter for formatting values in column chart 
+          formatData(chart.options, data, chart.data.length)
+          
           chart.chart = new google.visualization.BarChart(chart.element);
           resize(function () {
             chart.chart.draw(data, options);
@@ -626,6 +652,7 @@
           };
           var options = jsOptions(chart.data, chart.options, chartOptions);
           var data = createDataTable(chart.data, chart.options.discrete ? "string" : "datetime");
+          formatData(chart.options, data, chart.data.length)
           chart.chart = new google.visualization.AreaChart(chart.element);
           resize(function () {
             chart.chart.draw(data, options);
@@ -733,6 +760,19 @@
 
     return series;
   }
+  
+  //new: format data with given formatter options 
+  function formatData(chartOptions, data, dataLength){
+    if (chartOptions.formatter){
+      var formatter = new google.visualization.NumberFormat(chartOptions.formatter);
+      var i = 1;
+      while (i <= dataLength ){
+        formatter.format(data,i);
+        i++;
+      }
+    }
+  }
+
 
   function processSimple(data) {
     var perfectData = toArr(data), i;
@@ -797,6 +837,8 @@
     Chartkick.charts[element.id] = chart;
     fetchDataSource(chart, callback);
   }
+  
+  
 
   // define classes
 


### PR DESCRIPTION
Fixed #145 and makes it possible to format numbers, not only in pie charts, but also in bar charts, column charts.

Example for usage:
@data = {"Football" => 10.3, "Basketball" => 5.45, "Tennis" => 3.2}
@options = {"formatter" => {prefix: "$", decimalSymbol: ','}}
<%= pie_chart(@data, @options) %>

In formatter all options of https://developers.google.com/chart/interactive/docs/reference#numberformatter are allowed.
