### PR TITLE
change default curveType

### DIFF
--- a/app/assets/javascripts/chartkick.js
+++ b/app/assets/javascripts/chartkick.js
@@ -455,7 +455,7 @@
           alignment: "center",
           position: "right"
         },
-        curveType: "function",
+        curveType: "none",
         hAxis: {
           textStyle: {
             color: "#666",


### PR DESCRIPTION
I suggest the default curveType should be set to "null". 
In the description of the [Configuration Options](https://google-developers.appspot.com/chart/interactive/docs/gallery/linechart#configuration-options), curveType option is set to default 'null', so it seems to be easier to use if the default is same as Google Charts.