### PR TITLE
Auto load adapters if any loaded.

### DIFF
--- a/app/assets/javascripts/chartkick.js
+++ b/app/assets/javascripts/chartkick.js
@@ -235,519 +235,523 @@
     return a[0].getTime() - b[0].getTime();
   }
 
-  if ("Highcharts" in window) {
-    var HighchartsAdapter = new function () {
-      var Highcharts = window.Highcharts;
+  function loadAdapters(){
+    adapters = [];
+    if ("Highcharts" in window) {
+      var HighchartsAdapter = new function () {
+        var Highcharts = window.Highcharts;
 
-      this.name = "highcharts";
+        this.name = "highcharts";
 
-      var defaultOptions = {
-        chart: {},
-        xAxis: {
+        var defaultOptions = {
+          chart: {},
+          xAxis: {
+            title: {
+              text: null
+            },
+            labels: {
+              style: {
+                fontSize: "12px"
+              }
+            }
+          },
+          yAxis: {
+            title: {
+              text: null
+            },
+            labels: {
+              style: {
+                fontSize: "12px"
+              }
+            }
+          },
           title: {
             text: null
           },
-          labels: {
-            style: {
-              fontSize: "12px"
-            }
-          }
-        },
-        yAxis: {
-          title: {
-            text: null
+          credits: {
+            enabled: false
           },
-          labels: {
+          legend: {
+            borderWidth: 0
+          },
+          tooltip: {
             style: {
               fontSize: "12px"
             }
+          },
+          plotOptions: {
+            areaspline: {},
+            series: {
+              marker: {}
+            }
           }
-        },
-        title: {
-          text: null
-        },
-        credits: {
-          enabled: false
-        },
-        legend: {
-          borderWidth: 0
-        },
-        tooltip: {
-          style: {
-            fontSize: "12px"
-          }
-        },
-        plotOptions: {
-          areaspline: {},
-          series: {
-            marker: {}
-          }
-        }
-      };
+        };
 
-      var hideLegend = function (options) {
-        options.legend.enabled = false;
-      };
+        var hideLegend = function (options) {
+          options.legend.enabled = false;
+        };
 
-      var setMin = function (options, min) {
-        options.yAxis.min = min;
-      };
+        var setMin = function (options, min) {
+          options.yAxis.min = min;
+        };
 
-      var setMax = function (options, max) {
-        options.yAxis.max = max;
-      };
+        var setMax = function (options, max) {
+          options.yAxis.max = max;
+        };
 
-      var setStacked = function (options) {
-        options.plotOptions.series.stacking = "normal";
-      };
+        var setStacked = function (options) {
+          options.plotOptions.series.stacking = "normal";
+        };
 
-      var setXtitle = function (options, title) {
-        options.xAxis.title.text = title;
-      };
+        var setXtitle = function (options, title) {
+          options.xAxis.title.text = title;
+        };
 
-      var setYtitle = function (options, title) {
-        options.yAxis.title.text = title;
-      };
+        var setYtitle = function (options, title) {
+          options.yAxis.title.text = title;
+        };
 
-      var jsOptions = jsOptionsFunc(defaultOptions, hideLegend, setMin, setMax, setStacked, setXtitle, setYtitle);
+        var jsOptions = jsOptionsFunc(defaultOptions, hideLegend, setMin, setMax, setStacked, setXtitle, setYtitle);
 
-      this.renderLineChart = function (chart, chartType) {
-        chartType = chartType || "spline";
-        var chartOptions = {};
-        if (chartType === "areaspline") {
-          chartOptions = {
-            plotOptions: {
-              areaspline: {
-                stacking: "normal"
-              },
-              series: {
-                marker: {
-                  enabled: false
+        this.renderLineChart = function (chart, chartType) {
+          chartType = chartType || "spline";
+          var chartOptions = {};
+          if (chartType === "areaspline") {
+            chartOptions = {
+              plotOptions: {
+                areaspline: {
+                  stacking: "normal"
+                },
+                series: {
+                  marker: {
+                    enabled: false
+                  }
                 }
               }
-            }
-          };
-        }
-        var options = jsOptions(chart.data, chart.options, chartOptions), data, i, j;
-        options.xAxis.type = chart.options.discrete ? "category" : "datetime";
-        options.chart.type = chartType;
-        options.chart.renderTo = chart.element.id;
-
-        var series = chart.data;
-        for (i = 0; i < series.length; i++) {
-          data = series[i].data;
-          if (!chart.options.discrete) {
-            for (j = 0; j < data.length; j++) {
-              data[j][0] = data[j][0].getTime();
-            }
+            };
           }
-          series[i].marker = {symbol: "circle"};
-        }
-        options.series = series;
-        new Highcharts.Chart(options);
-      };
+          var options = jsOptions(chart.data, chart.options, chartOptions), data, i, j;
+          options.xAxis.type = chart.options.discrete ? "category" : "datetime";
+          options.chart.type = chartType;
+          options.chart.renderTo = chart.element.id;
 
-      this.renderScatterChart = function (chart) {
-        var chartOptions = {};
-        var options = jsOptions(chart.data, chart.options, chartOptions);
-        options.chart.type = 'scatter';
-        options.chart.renderTo = chart.element.id;
-        options.series = chart.data;
-        new Highcharts.Chart(options);
-      };
-
-      this.renderPieChart = function (chart) {
-        var chartOptions = {};
-        if (chart.options.colors) {
-          chartOptions.colors = chart.options.colors;
-        }
-        var options = merge(merge(defaultOptions, chartOptions), chart.options.library || {});
-        options.chart.renderTo = chart.element.id;
-        options.series = [{
-          type: "pie",
-          name: "Value",
-          data: chart.data
-        }];
-        new Highcharts.Chart(options);
-      };
-
-      this.renderColumnChart = function (chart, chartType) {
-        var chartType = chartType || "column";
-        var series = chart.data;
-        var options = jsOptions(series, chart.options), i, j, s, d, rows = [];
-        options.chart.type = chartType;
-        options.chart.renderTo = chart.element.id;
-
-        for (i = 0; i < series.length; i++) {
-          s = series[i];
-
-          for (j = 0; j < s.data.length; j++) {
-            d = s.data[j];
-            if (!rows[d[0]]) {
-              rows[d[0]] = new Array(series.length);
-            }
-            rows[d[0]][i] = d[1];
-          }
-        }
-
-        var categories = [];
-        for (i in rows) {
-          if (rows.hasOwnProperty(i)) {
-            categories.push(i);
-          }
-        }
-        options.xAxis.categories = categories;
-
-        var newSeries = [];
-        for (i = 0; i < series.length; i++) {
-          d = [];
-          for (j = 0; j < categories.length; j++) {
-            d.push(rows[categories[j]][i] || 0);
-          }
-
-          newSeries.push({
-            name: series[i].name,
-            data: d
-          });
-        }
-        options.series = newSeries;
-
-        new Highcharts.Chart(options);
-      };
-
-      var self = this;
-
-      this.renderBarChart = function (chart) {
-        self.renderColumnChart(chart, "bar");
-      };
-
-      this.renderAreaChart = function (chart) {
-        self.renderLineChart(chart, "areaspline");
-      };
-    };
-    adapters.push(HighchartsAdapter);
-  }
-  if (window.google && window.google.setOnLoadCallback) {
-    var GoogleChartsAdapter = new function () {
-      var google = window.google;
-
-      this.name = "google";
-
-      var loaded = {};
-      var callbacks = [];
-
-      var runCallbacks = function () {
-        var cb, call;
-        for (var i = 0; i < callbacks.length; i++) {
-          cb = callbacks[i];
-          call = google.visualization && ((cb.pack === "corechart" && google.visualization.LineChart) || (cb.pack === "timeline" && google.visualization.Timeline))
-          if (call) {
-            cb.callback();
-            callbacks.splice(i, 1);
-            i--;
-          }
-        }
-      };
-
-      var waitForLoaded = function (pack, callback) {
-        if (!callback) {
-          callback = pack;
-          pack = "corechart";
-        }
-
-        callbacks.push({pack: pack, callback: callback});
-
-        if (loaded[pack]) {
-          runCallbacks();
-        } else {
-          loaded[pack] = true;
-
-          // https://groups.google.com/forum/#!topic/google-visualization-api/fMKJcyA2yyI
-          var loadOptions = {
-            packages: [pack],
-            callback: runCallbacks
-          };
-          if (config.language) {
-            loadOptions.language = config.language;
-          }
-          google.load("visualization", "1", loadOptions);
-        }
-      };
-
-      // Set chart options
-      var defaultOptions = {
-        chartArea: {},
-        fontName: "'Lucida Grande', 'Lucida Sans Unicode', Verdana, Arial, Helvetica, sans-serif",
-        pointSize: 6,
-        legend: {
-          textStyle: {
-            fontSize: 12,
-            color: "#444"
-          },
-          alignment: "center",
-          position: "right"
-        },
-        curveType: "function",
-        hAxis: {
-          textStyle: {
-            color: "#666",
-            fontSize: 12
-          },
-          titleTextStyle: {},
-          gridlines: {
-            color: "transparent"
-          },
-          baselineColor: "#ccc",
-          viewWindow: {}
-        },
-        vAxis: {
-          textStyle: {
-            color: "#666",
-            fontSize: 12
-          },
-          titleTextStyle: {},
-          baselineColor: "#ccc",
-          viewWindow: {}
-        },
-        tooltip: {
-          textStyle: {
-            color: "#666",
-            fontSize: 12
-          }
-        }
-      };
-
-      var hideLegend = function (options) {
-        options.legend.position = "none";
-      };
-
-      var setMin = function (options, min) {
-        options.vAxis.viewWindow.min = min;
-      };
-
-      var setMax = function (options, max) {
-        options.vAxis.viewWindow.max = max;
-      };
-
-      var setBarMin = function (options, min) {
-        options.hAxis.viewWindow.min = min;
-      };
-
-      var setBarMax = function (options, max) {
-        options.hAxis.viewWindow.max = max;
-      };
-
-      var setStacked = function (options) {
-        options.isStacked = true;
-      };
-
-      var setXtitle = function (options, title) {
-        options.hAxis.title = title;
-        options.hAxis.titleTextStyle.italic = false;
-      }
-
-      var setYtitle = function (options, title) {
-        options.vAxis.title = title;
-        options.vAxis.titleTextStyle.italic = false;
-      };
-
-      var jsOptions = jsOptionsFunc(defaultOptions, hideLegend, setMin, setMax, setStacked, setXtitle, setYtitle);
-
-      // cant use object as key
-      var createDataTable = function (series, columnType) {
-        var data = new google.visualization.DataTable();
-        data.addColumn(columnType, "");
-
-        var i, j, s, d, key, rows = [];
-        for (i = 0; i < series.length; i++) {
-          s = series[i];
-          data.addColumn("number", s.name);
-
-          for (j = 0; j < s.data.length; j++) {
-            d = s.data[j];
-            key = (columnType === "datetime") ? d[0].getTime() : d[0];
-            if (!rows[key]) {
-              rows[key] = new Array(series.length);
-            }
-            rows[key][i] = toFloat(d[1]);
-          }
-        }
-
-        var rows2 = [];
-        var value;
-        for (i in rows) {
-          if (rows.hasOwnProperty(i)) {
-            if (columnType === "datetime") {
-              value = new Date(toFloat(i));
-            } else if (columnType === "number") {
-              value = toFloat(i);
-            } else {
-              value = i;
-            }
-            rows2.push([value].concat(rows[i]));
-          }
-        }
-        if (columnType === "datetime") {
-          rows2.sort(sortByTime);
-        }
-        data.addRows(rows2);
-
-        return data;
-      };
-
-      var resize = function (callback) {
-        if (window.attachEvent) {
-          window.attachEvent("onresize", callback);
-        } else if (window.addEventListener) {
-          window.addEventListener("resize", callback, true);
-        }
-        callback();
-      };
-
-      this.renderLineChart = function (chart) {
-        waitForLoaded(function () {
-          var options = jsOptions(chart.data, chart.options);
-          var data = createDataTable(chart.data, chart.options.discrete ? "string" : "datetime");
-          chart.chart = new google.visualization.LineChart(chart.element);
-          resize(function () {
-            chart.chart.draw(data, options);
-          });
-        });
-      };
-
-      this.renderPieChart = function (chart) {
-        waitForLoaded(function () {
-          var chartOptions = {
-            chartArea: {
-              top: "10%",
-              height: "80%"
-            }
-          };
-          if (chart.options.colors) {
-            chartOptions.colors = chart.options.colors;
-          }
-          var options = merge(merge(defaultOptions, chartOptions), chart.options.library || {});
-
-          var data = new google.visualization.DataTable();
-          data.addColumn("string", "");
-          data.addColumn("number", "Value");
-          data.addRows(chart.data);
-
-          chart.chart = new google.visualization.PieChart(chart.element);
-          resize(function () {
-            chart.chart.draw(data, options);
-          });
-        });
-      };
-
-      this.renderColumnChart = function (chart) {
-        waitForLoaded(function () {
-          var options = jsOptions(chart.data, chart.options);
-          var data = createDataTable(chart.data, "string");
-          chart.chart = new google.visualization.ColumnChart(chart.element);
-          resize(function () {
-            chart.chart.draw(data, options);
-          });
-        });
-      };
-
-      this.renderBarChart = function (chart) {
-        waitForLoaded(function () {
-          var chartOptions = {
-            hAxis: {
-              gridlines: {
-                color: "#ccc"
+          var series = chart.data;
+          for (i = 0; i < series.length; i++) {
+            data = series[i].data;
+            if (!chart.options.discrete) {
+              for (j = 0; j < data.length; j++) {
+                data[j][0] = data[j][0].getTime();
               }
             }
-          };
-          var options = jsOptionsFunc(defaultOptions, hideLegend, setBarMin, setBarMax, setStacked)(chart.data, chart.options, chartOptions);
-          var data = createDataTable(chart.data, "string");
-          chart.chart = new google.visualization.BarChart(chart.element);
-          resize(function () {
-            chart.chart.draw(data, options);
-          });
-        });
-      };
+            series[i].marker = {symbol: "circle"};
+          }
+          options.series = series;
+          new Highcharts.Chart(options);
+        };
 
-      this.renderAreaChart = function (chart) {
-        waitForLoaded(function () {
-          var chartOptions = {
-            isStacked: true,
-            pointSize: 0,
-            areaOpacity: 0.5
-          };
-          var options = jsOptions(chart.data, chart.options, chartOptions);
-          var data = createDataTable(chart.data, chart.options.discrete ? "string" : "datetime");
-          chart.chart = new google.visualization.AreaChart(chart.element);
-          resize(function () {
-            chart.chart.draw(data, options);
-          });
-        });
-      };
-
-      this.renderGeoChart = function (chart) {
-        waitForLoaded(function () {
-          var chartOptions = {
-            legend: "none",
-            colorAxis: {
-              colors: chart.options.colors || ["#f6c7b6", "#ce502d"]
-            }
-          };
-          var options = merge(merge(defaultOptions, chartOptions), chart.options.library || {});
-
-          var data = new google.visualization.DataTable();
-          data.addColumn("string", "");
-          data.addColumn("number", "Value");
-          data.addRows(chart.data);
-
-          chart.chart = new google.visualization.GeoChart(chart.element);
-          resize(function () {
-            chart.chart.draw(data, options);
-          });
-        });
-      };
-
-      this.renderScatterChart = function (chart) {
-        waitForLoaded(function () {
+        this.renderScatterChart = function (chart) {
           var chartOptions = {};
           var options = jsOptions(chart.data, chart.options, chartOptions);
-          var data = createDataTable(chart.data, "number");
+          options.chart.type = 'scatter';
+          options.chart.renderTo = chart.element.id;
+          options.series = chart.data;
+          new Highcharts.Chart(options);
+        };
 
-          chart.chart = new google.visualization.ScatterChart(chart.element);
-          resize(function () {
-            chart.chart.draw(data, options);
-          });
-        });
-      };
-
-      this.renderTimeline = function (chart) {
-        waitForLoaded("timeline", function () {
-          var chartOptions = {
-            legend: "none"
-          };
-
+        this.renderPieChart = function (chart) {
+          var chartOptions = {};
           if (chart.options.colors) {
             chartOptions.colors = chart.options.colors;
           }
           var options = merge(merge(defaultOptions, chartOptions), chart.options.library || {});
+          options.chart.renderTo = chart.element.id;
+          options.series = [{
+            type: "pie",
+            name: "Value",
+            data: chart.data
+          }];
+          new Highcharts.Chart(options);
+        };
 
-          var data = new google.visualization.DataTable();
-          data.addColumn({type: "string", id: "Name"});
-          data.addColumn({type: "date", id: "Start"});
-          data.addColumn({type: "date", id: "End"});
-          data.addRows(chart.data);
+        this.renderColumnChart = function (chart, chartType) {
+          var chartType = chartType || "column";
+          var series = chart.data;
+          var options = jsOptions(series, chart.options), i, j, s, d, rows = [];
+          options.chart.type = chartType;
+          options.chart.renderTo = chart.element.id;
 
-          chart.chart = new google.visualization.Timeline(chart.element);
+          for (i = 0; i < series.length; i++) {
+            s = series[i];
 
-          resize(function () {
-            chart.chart.draw(data, options);
-          });
-        });
+            for (j = 0; j < s.data.length; j++) {
+              d = s.data[j];
+              if (!rows[d[0]]) {
+                rows[d[0]] = new Array(series.length);
+              }
+              rows[d[0]][i] = d[1];
+            }
+          }
+
+          var categories = [];
+          for (i in rows) {
+            if (rows.hasOwnProperty(i)) {
+              categories.push(i);
+            }
+          }
+          options.xAxis.categories = categories;
+
+          var newSeries = [];
+          for (i = 0; i < series.length; i++) {
+            d = [];
+            for (j = 0; j < categories.length; j++) {
+              d.push(rows[categories[j]][i] || 0);
+            }
+
+            newSeries.push({
+              name: series[i].name,
+              data: d
+            });
+          }
+          options.series = newSeries;
+
+          new Highcharts.Chart(options);
+        };
+
+        var self = this;
+
+        this.renderBarChart = function (chart) {
+          self.renderColumnChart(chart, "bar");
+        };
+
+        this.renderAreaChart = function (chart) {
+          self.renderLineChart(chart, "areaspline");
+        };
       };
-    };
+      adapters.push(HighchartsAdapter);
+    }
+    if (window.google && window.google.setOnLoadCallback) {
+      var GoogleChartsAdapter = new function () {
+        var google = window.google;
 
-    adapters.push(GoogleChartsAdapter);
+        this.name = "google";
+
+        var loaded = {};
+        var callbacks = [];
+
+        var runCallbacks = function () {
+          var cb, call;
+          for (var i = 0; i < callbacks.length; i++) {
+            cb = callbacks[i];
+            call = google.visualization && ((cb.pack === "corechart" && google.visualization.LineChart) || (cb.pack === "timeline" && google.visualization.Timeline))
+            if (call) {
+              cb.callback();
+              callbacks.splice(i, 1);
+              i--;
+            }
+          }
+        };
+
+        var waitForLoaded = function (pack, callback) {
+          if (!callback) {
+            callback = pack;
+            pack = "corechart";
+          }
+
+          callbacks.push({pack: pack, callback: callback});
+
+          if (loaded[pack]) {
+            runCallbacks();
+          } else {
+            loaded[pack] = true;
+
+            // https://groups.google.com/forum/#!topic/google-visualization-api/fMKJcyA2yyI
+            var loadOptions = {
+              packages: [pack],
+              callback: runCallbacks
+            };
+            if (config.language) {
+              loadOptions.language = config.language;
+            }
+            google.load("visualization", "1", loadOptions);
+          }
+        };
+
+        // Set chart options
+        var defaultOptions = {
+          chartArea: {},
+          fontName: "'Lucida Grande', 'Lucida Sans Unicode', Verdana, Arial, Helvetica, sans-serif",
+          pointSize: 6,
+          legend: {
+            textStyle: {
+              fontSize: 12,
+              color: "#444"
+            },
+            alignment: "center",
+            position: "right"
+          },
+          curveType: "function",
+          hAxis: {
+            textStyle: {
+              color: "#666",
+              fontSize: 12
+            },
+            titleTextStyle: {},
+            gridlines: {
+              color: "transparent"
+            },
+            baselineColor: "#ccc",
+            viewWindow: {}
+          },
+          vAxis: {
+            textStyle: {
+              color: "#666",
+              fontSize: 12
+            },
+            titleTextStyle: {},
+            baselineColor: "#ccc",
+            viewWindow: {}
+          },
+          tooltip: {
+            textStyle: {
+              color: "#666",
+              fontSize: 12
+            }
+          }
+        };
+
+        var hideLegend = function (options) {
+          options.legend.position = "none";
+        };
+
+        var setMin = function (options, min) {
+          options.vAxis.viewWindow.min = min;
+        };
+
+        var setMax = function (options, max) {
+          options.vAxis.viewWindow.max = max;
+        };
+
+        var setBarMin = function (options, min) {
+          options.hAxis.viewWindow.min = min;
+        };
+
+        var setBarMax = function (options, max) {
+          options.hAxis.viewWindow.max = max;
+        };
+
+        var setStacked = function (options) {
+          options.isStacked = true;
+        };
+
+        var setXtitle = function (options, title) {
+          options.hAxis.title = title;
+          options.hAxis.titleTextStyle.italic = false;
+        }
+
+        var setYtitle = function (options, title) {
+          options.vAxis.title = title;
+          options.vAxis.titleTextStyle.italic = false;
+        };
+
+        var jsOptions = jsOptionsFunc(defaultOptions, hideLegend, setMin, setMax, setStacked, setXtitle, setYtitle);
+
+        // cant use object as key
+        var createDataTable = function (series, columnType) {
+          var data = new google.visualization.DataTable();
+          data.addColumn(columnType, "");
+
+          var i, j, s, d, key, rows = [];
+          for (i = 0; i < series.length; i++) {
+            s = series[i];
+            data.addColumn("number", s.name);
+
+            for (j = 0; j < s.data.length; j++) {
+              d = s.data[j];
+              key = (columnType === "datetime") ? d[0].getTime() : d[0];
+              if (!rows[key]) {
+                rows[key] = new Array(series.length);
+              }
+              rows[key][i] = toFloat(d[1]);
+            }
+          }
+
+          var rows2 = [];
+          var value;
+          for (i in rows) {
+            if (rows.hasOwnProperty(i)) {
+              if (columnType === "datetime") {
+                value = new Date(toFloat(i));
+              } else if (columnType === "number") {
+                value = toFloat(i);
+              } else {
+                value = i;
+              }
+              rows2.push([value].concat(rows[i]));
+            }
+          }
+          if (columnType === "datetime") {
+            rows2.sort(sortByTime);
+          }
+          data.addRows(rows2);
+
+          return data;
+        };
+
+        var resize = function (callback) {
+          if (window.attachEvent) {
+            window.attachEvent("onresize", callback);
+          } else if (window.addEventListener) {
+            window.addEventListener("resize", callback, true);
+          }
+          callback();
+        };
+
+        this.renderLineChart = function (chart) {
+          waitForLoaded(function () {
+            var options = jsOptions(chart.data, chart.options);
+            var data = createDataTable(chart.data, chart.options.discrete ? "string" : "datetime");
+            chart.chart = new google.visualization.LineChart(chart.element);
+            resize(function () {
+              chart.chart.draw(data, options);
+            });
+          });
+        };
+
+        this.renderPieChart = function (chart) {
+          waitForLoaded(function () {
+            var chartOptions = {
+              chartArea: {
+                top: "10%",
+                height: "80%"
+              }
+            };
+            if (chart.options.colors) {
+              chartOptions.colors = chart.options.colors;
+            }
+            var options = merge(merge(defaultOptions, chartOptions), chart.options.library || {});
+
+            var data = new google.visualization.DataTable();
+            data.addColumn("string", "");
+            data.addColumn("number", "Value");
+            data.addRows(chart.data);
+
+            chart.chart = new google.visualization.PieChart(chart.element);
+            resize(function () {
+              chart.chart.draw(data, options);
+            });
+          });
+        };
+
+        this.renderColumnChart = function (chart) {
+          waitForLoaded(function () {
+            var options = jsOptions(chart.data, chart.options);
+            var data = createDataTable(chart.data, "string");
+            chart.chart = new google.visualization.ColumnChart(chart.element);
+            resize(function () {
+              chart.chart.draw(data, options);
+            });
+          });
+        };
+
+        this.renderBarChart = function (chart) {
+          waitForLoaded(function () {
+            var chartOptions = {
+              hAxis: {
+                gridlines: {
+                  color: "#ccc"
+                }
+              }
+            };
+            var options = jsOptionsFunc(defaultOptions, hideLegend, setBarMin, setBarMax, setStacked)(chart.data, chart.options, chartOptions);
+            var data = createDataTable(chart.data, "string");
+            chart.chart = new google.visualization.BarChart(chart.element);
+            resize(function () {
+              chart.chart.draw(data, options);
+            });
+          });
+        };
+
+        this.renderAreaChart = function (chart) {
+          waitForLoaded(function () {
+            var chartOptions = {
+              isStacked: true,
+              pointSize: 0,
+              areaOpacity: 0.5
+            };
+            var options = jsOptions(chart.data, chart.options, chartOptions);
+            var data = createDataTable(chart.data, chart.options.discrete ? "string" : "datetime");
+            chart.chart = new google.visualization.AreaChart(chart.element);
+            resize(function () {
+              chart.chart.draw(data, options);
+            });
+          });
+        };
+
+        this.renderGeoChart = function (chart) {
+          waitForLoaded(function () {
+            var chartOptions = {
+              legend: "none",
+              colorAxis: {
+                colors: chart.options.colors || ["#f6c7b6", "#ce502d"]
+              }
+            };
+            var options = merge(merge(defaultOptions, chartOptions), chart.options.library || {});
+
+            var data = new google.visualization.DataTable();
+            data.addColumn("string", "");
+            data.addColumn("number", "Value");
+            data.addRows(chart.data);
+
+            chart.chart = new google.visualization.GeoChart(chart.element);
+            resize(function () {
+              chart.chart.draw(data, options);
+            });
+          });
+        };
+
+        this.renderScatterChart = function (chart) {
+          waitForLoaded(function () {
+            var chartOptions = {};
+            var options = jsOptions(chart.data, chart.options, chartOptions);
+            var data = createDataTable(chart.data, "number");
+
+            chart.chart = new google.visualization.ScatterChart(chart.element);
+            resize(function () {
+              chart.chart.draw(data, options);
+            });
+          });
+        };
+
+        this.renderTimeline = function (chart) {
+          waitForLoaded("timeline", function () {
+            var chartOptions = {
+              legend: "none"
+            };
+
+            if (chart.options.colors) {
+              chartOptions.colors = chart.options.colors;
+            }
+            var options = merge(merge(defaultOptions, chartOptions), chart.options.library || {});
+
+            var data = new google.visualization.DataTable();
+            data.addColumn({type: "string", id: "Name"});
+            data.addColumn({type: "date", id: "Start"});
+            data.addColumn({type: "date", id: "End"});
+            data.addRows(chart.data);
+
+            chart.chart = new google.visualization.Timeline(chart.element);
+
+            resize(function () {
+              chart.chart.draw(data, options);
+            });
+          });
+        };
+      };
+
+      adapters.push(GoogleChartsAdapter);
+    }
   }
+  loadAdapters()
 
   // TODO remove chartType if cross-browser way
   // to get the name of the chart class
@@ -755,6 +759,10 @@
     var i, adapter, fnName, adapterName;
     fnName = "render" + chartType;
     adapterName = chart.options.adapter;
+
+    if(adapters.length == 0) {
+      loadAdapters()
+    }
 
     for (i = 0; i < adapters.length; i++) {
       adapter = adapters[i];


### PR DESCRIPTION
I don't like to add the JSAPI javascript inside my html head because if it slow down all my website is slowing down... :disappointed:

The new behaviors is this : 
Load the adapters at the begining, but before rendering, if there are no adapters try to load them again.

I just added the ability to load chartkick inside my application json and use something like this : 

```
    $.getscript '//www.google.com/jsapi', ->
          new Chartkick[graph_type](id, values, options)
```

Which will load the script asynchronously.

If your are using angularJS you can even do that quickly this :

```
angular.module('chartkick', [])
  .factory 'ChartkickJSAPI', ($q)->
    defer = $q.defer()
    $.getscript '//www.google.com/jsapi', ->
      defer.resolve(true)
    defer.promise
  .directive 'chartkick', (ChartkickJSAPI)->
    restrict: 'A'
    link: (scope, elem, attrs)->
      scope.$watch attrs['chartkick'], (values, old_values)->
        return unless values?
        graph_type = attrs['type']
        options = scope.$eval(attrs['chartoptions']) || {}
        id = elem.prop('id')
        ChartkickJSAPI.then ->
          new Chartkick[graph_type](id, values, options)
```

What do you think ?