### PR TITLE
Rails 5 precompilation

### DIFF
--- a/lib/chartkick/engine.rb
+++ b/lib/chartkick/engine.rb
@@ -1,8 +1,12 @@
 module Chartkick
   class Engine < ::Rails::Engine
     initializer "precompile", group: :all do |app|
-      # use a proc instead of a string
-      app.config.assets.precompile << 'chartkick.js'
+      # use a string in rails >= 5
+      if Gem::Requirement.new(">= 5.0.0.beta").satisfied_by?(Gem::Version.new(Rails.version))
+        app.config.assets.precompile << 'chartkick.js'
+      else
+        app.config.assets.precompile << proc { |path| path == "chartkick.js" }
+      end
     end
 
     initializer "helper" do

--- a/lib/chartkick/engine.rb
+++ b/lib/chartkick/engine.rb
@@ -2,7 +2,7 @@ module Chartkick
   class Engine < ::Rails::Engine
     initializer "precompile", group: :all do |app|
       # use a proc instead of a string
-      app.config.assets.precompile << proc { |path| path == "chartkick.js" }
+      app.config.assets.precompile << 'chartkick.js'
     end
 
     initializer "helper" do


### PR DESCRIPTION
The Proc syntax for precompilation of assets is gone in rails master. Changing this to just a string fixes the compatibility issues I came across when using this gem with Rails 5.