### PR TITLE
Making line height default value to be 20px

### DIFF
--- a/app/assets/javascripts/chartkick.js
+++ b/app/assets/javascripts/chartkick.js
@@ -735,6 +735,7 @@
           data.addColumn({type: "string", id: "Name"});
           data.addColumn({type: "date", id: "Start"});
           data.addColumn({type: "date", id: "End"});
+          console.log(chart.data[1]);
           data.addRows(chart.data);
 
           chart.chart = new google.visualization.Timeline(chart.element);

--- a/lib/chartkick/helper.rb
+++ b/lib/chartkick/helper.rb
@@ -42,10 +42,11 @@ module Chartkick
       options = chartkick_deep_merge(Chartkick.options, options)
       element_id = options.delete(:id) || "chart-#{@chartkick_chart_id += 1}"
       height = options.delete(:height) || "300px"
+      line_height = options.delete(:line_height) || "20px"
       # content_for: nil must override default
       content_for = options.key?(:content_for) ? options.delete(:content_for) : Chartkick.content_for
 
-      html = (options.delete(:html) || %(<div id="%{id}" style="height: %{height}; text-align: center; color: #999; line-height: %{height}; font-size: 14px; font-family: 'Lucida Grande', 'Lucida Sans Unicode', Verdana, Arial, Helvetica, sans-serif;">Loading...</div>)) % {id: ERB::Util.html_escape(element_id), height: ERB::Util.html_escape(height)}
+      html = (options.delete(:html) || %(<div id="%{id}" style="height: %{height}; text-align: center; color: #999; line-height: %{line_height}; font-size: 14px; font-family: 'Lucida Grande', 'Lucida Sans Unicode', Verdana, Arial, Helvetica, sans-serif;">Loading...</div>)) % {id: ERB::Util.html_escape(element_id), height: ERB::Util.html_escape(height), line_height: ERB::Util.html_escape(line_height)}
 
       js = <<JS
 <script type="text/javascript">


### PR DESCRIPTION
The tooltip view in the timeline charts seems to be taking a default value of 300px or, uses the value of the `height` option, which is the height of the chart thus making the tooltip view hard to read.

This PR should default it to 20px, also allows it to be configured by setting `line_height`.