### PR TITLE
fix for rails regarding sprockets version

### DIFF
--- a/lib/chartkick/engine.rb
+++ b/lib/chartkick/engine.rb
@@ -1,7 +1,7 @@
 module Chartkick
   class Engine < ::Rails::Engine
     initializer "precompile", group: :all do |app|
-      if Rails::VERSION::MAJOR >= 5
+      if Gem::Version.new(Sprockets::VERSION) > Gem::Version.new("3.5.2")
         app.config.assets.precompile << "chartkick.js"
       else
         # use a proc instead of a string

--- a/lib/chartkick/engine.rb
+++ b/lib/chartkick/engine.rb
@@ -1,7 +1,7 @@
 module Chartkick
   class Engine < ::Rails::Engine
     initializer "precompile", group: :all do |app|
-      if Gem::Version.new(Sprockets::VERSION) > Gem::Version.new("3.5.2")
+      if Gem::Version.new(Sprockets::VERSION) >= Gem::Version.new("4.0.0.beta1")
         app.config.assets.precompile << "chartkick.js"
       else
         # use a proc instead of a string


### PR DESCRIPTION
Hey guys, 
I'm running Rails 4.2 and I tried upgrading to sprockets 5.
Everything is running smooth except for `chartkick` failling on the Proc.new error.
This fixes it!

LMK what you guys think