### PR TITLE
Support Sankey, Google chart

### DIFF
--- a/app/assets/javascripts/chartkick.js
+++ b/app/assets/javascripts/chartkick.js
@@ -914,7 +914,6 @@
   }
 
   function processSankeyData(chart) {
-    //chart.data = processSimple(chart.data);
     renderChart("Sankey", chart);
   }
 

--- a/app/assets/javascripts/chartkick.js
+++ b/app/assets/javascripts/chartkick.js
@@ -757,16 +757,13 @@
         this.renderSankey = function (chart) {
           waitForLoaded(function () {
             var chartOptions = {
-              width: 900,
-              height: 600,
               sankey: {
                 node: {
                   interactivity: true
                 }
               }
             };
-            //var options = jsOptions(chart.data, chart.options, chartOptions);
-            var options = chartOptions;
+            var options = merge(merge(defaultOptions, chartOptions), chart.options.library || {});
 
             var data = new google.visualization.DataTable();
             data.addColumn({type: "string", id: "From"});

--- a/app/assets/javascripts/chartkick.js
+++ b/app/assets/javascripts/chartkick.js
@@ -753,6 +753,34 @@
             });
           });
         };
+
+        this.renderSankey = function (chart) {
+          waitForLoaded(function () {
+            var chartOptions = {
+              width: 900,
+              height: 600,
+              sankey: {
+                node: {
+                  interactivity: true
+                }
+              }
+            };
+            //var options = jsOptions(chart.data, chart.options, chartOptions);
+            var options = chartOptions;
+
+            var data = new google.visualization.DataTable();
+            data.addColumn({type: "string", id: "From"});
+            data.addColumn({type: "string", id: "To"});
+            data.addColumn({type: "number", id: "Weight"});
+            data.addRows(chart.data);
+
+            chart.chart = new google.visualization.Sankey(chart.element);
+
+            resize(function () {
+              chart.chart.draw(data, options);
+            });
+          });
+        };
       };
 
       adapters.push(GoogleChartsAdapter);
@@ -888,6 +916,11 @@
     renderChart("Timeline", chart);
   }
 
+  function processSankeyData(chart) {
+    //chart.data = processSimple(chart.data);
+    renderChart("Sankey", chart);
+  }
+
   function setElement(chart, element, dataSource, opts, callback) {
     if (typeof element === "string") {
       element = document.getElementById(element);
@@ -925,6 +958,9 @@
     },
     Timeline: function (element, dataSource, opts) {
       setElement(this, element, dataSource, opts, processTimelineData);
+    },
+    Sankey: function (element, dataSource, opts) {
+      setElement(this, element, dataSource, opts, processSankeyData);
     },
     charts: {}
   };

--- a/lib/chartkick/helper.rb
+++ b/lib/chartkick/helper.rb
@@ -35,6 +35,10 @@ module Chartkick
       chartkick_chart "Timeline", data_source, options
     end
 
+    def sankey(data_source, options = {})
+      chartkick_chart "Sankey", data_source, options
+    end
+
     private
 
     def chartkick_chart(klass, data_source, options)

--- a/lib/chartkick/version.rb
+++ b/lib/chartkick/version.rb
@@ -1,3 +1,3 @@
 module Chartkick
-  VERSION = "1.5.0"
+  VERSION = "1.4.2"
 end

--- a/lib/chartkick/version.rb
+++ b/lib/chartkick/version.rb
@@ -1,3 +1,3 @@
 module Chartkick
-  VERSION = "1.4.2"
+  VERSION = "1.5.0"
 end


### PR DESCRIPTION
Reads in path information like 
From: "a", To: "b", Weight: 20

Sankey module from Google API has to be loaded implicitly, such as:
`<%= javascript_include_tag "http://www.google.com/jsapi?autoload={'modules':[{'name':'visualization','version':'1.2','packages':['corechart','sankey']}]}", 'chartkick' %>`
