### PR TITLE
Merge options pass form method calling.

### DIFF
--- a/app/assets/javascripts/chartkick.js
+++ b/app/assets/javascripts/chartkick.js
@@ -643,10 +643,9 @@
                 height: "80%"
               }
             };
-            if (chart.options.colors) {
-              chartOptions.colors = chart.options.colors;
-            }
+
             var options = merge(merge(defaultOptions, chartOptions), chart.options.library || {});
+            options = merge(options, chart.options);
 
             var data = new google.visualization.DataTable();
             data.addColumn("string", "");


### PR DESCRIPTION
When I tried to pass options from view calling something like following, it not working. I found the method for google chart not merging passed parameters. This will take care about the passed parameters.

`<%= pie_chart data, {title: 'Chart Name', legend: 'none'} %>`

Example: It will now show you the chart title and hide legend.
