### PR TITLE
Add option to defer chart creation until after page load

### DIFF
--- a/lib/chartkick/helper.rb
+++ b/lib/chartkick/helper.rb
@@ -66,7 +66,11 @@ module Chartkick
 </script>
 JS
       else
-        js = '<script type="text/javascript">' + createjs + '</script>'
+        js = <<JS
+<script type="text/javascript">
+  #{createjs}
+</script>
+JS
       end
 
       if content_for

--- a/lib/chartkick/helper.rb
+++ b/lib/chartkick/helper.rb
@@ -54,7 +54,7 @@ module Chartkick
         js = <<JS
 <script type="text/javascript">
   (function() {
-    var createChart = function createChart() { #{createjs} };
+    var createChart = function() { #{createjs} };
     if (window.attachEvent) {
       window.attachEvent("onload", createChart);
     } else if (window.addEventListener) {

--- a/lib/chartkick/helper.rb
+++ b/lib/chartkick/helper.rb
@@ -55,10 +55,10 @@ module Chartkick
 <script type="text/javascript">
   (function() {
     var createChart = function() { #{createjs} };
-    if (window.attachEvent) {
-      window.attachEvent("onload", createChart);
-    } else if (window.addEventListener) {
+    if (window.addEventListener) {
       window.addEventListener("load", createChart, true);
+    } else if (window.attachEvent) {
+      window.attachEvent("onload", createChart);
     } else {
       createChart();
     }


### PR DESCRIPTION
Adds an option to execute Chartkick JS after page load rather than immediately. Useful if you're loading scripts async.

`line_chart data_source, defer: true`
