### PR TITLE
specify minor version for google visualization lib

### DIFF
--- a/app/assets/javascripts/chartkick.js
+++ b/app/assets/javascripts/chartkick.js
@@ -484,7 +484,7 @@
             if (config.language) {
               loadOptions.language = config.language;
             }
-            google.load("visualization", "1", loadOptions);
+            google.load("visualization", "1.0", loadOptions);
           }
         };
 


### PR DESCRIPTION
Hi, @ankane 

Thank you for the awesome library.
it occurred following error when to load google visualization lib with version `1`.

```
?file=visualization&v=1undefined&packages=corechart&async=2:1 
Uncaught Error: Module: 'visualization' with version: '1undefined' not found!(…)
```

I used Goggle chrome v55.0.2842(canary)
It seems that google's api failed to parse version number. it expected to be `X.X`, but `x`.
