### PR TITLE
Pass charttype in chart options for LineCharts

### DIFF
--- a/app/assets/javascripts/chartkick.js
+++ b/app/assets/javascripts/chartkick.js
@@ -344,7 +344,9 @@
           }
           var options = jsOptions(chart.data, chart.options, chartOptions), data, i, j;
           options.xAxis.type = chart.options.discrete ? "category" : "datetime";
-          options.chart.type = chartType;
+          if (!options.chart.type) {
+            options.chart.type = chartType;
+          }
           options.chart.renderTo = chart.element.id;
 
           var series = chart.data;


### PR DESCRIPTION
You can now pass the charttype variable in the library options for LineCharts.

This is particularly useful for Highcharts users, when you want a real LineChart (with type: line instead of type: spline) or an AreaChart with lines instead of splines.

Examples:

```
line_chart [name: 'test', data: [["A", 1], ["B", 2], ["C", 0], ["D", 1], ["E", 2], ["F", 2]],
                      pointPlacement: 'on',
                      fillColor: 'rgba(255,0,0,0.2)',
                      threshold: -1],
                      adapter: 'highcharts',
                      library: {chart: {polar: true, type: 'line'}}
```

```
line_chart [name: 'test', data: [["A", 1], ["B", 2], ["C", 0], ["D", 1], ["E", 2], ["F", 2]],
                      pointPlacement: 'on',
                      fillColor: 'rgba(255,0,0,0.2)',
                      threshold: -1],
                      adapter: 'highcharts',
                      library: {chart: {polar: true, type: 'area'}}
```