### PR TITLE
Added support for script-src CSP

### DIFF
--- a/lib/chartkick/helper.rb
+++ b/lib/chartkick/helper.rb
@@ -46,7 +46,7 @@ module Chartkick
       defer = !!options.delete(:defer)
       # content_for: nil must override default
       content_for = options.key?(:content_for) ? options.delete(:content_for) : Chartkick.content_for
-      nonce = options.key?(:nonce) ? %( nonce="%{nonce_value}")) % {nonce_value: ERB::Util.html_escape(options.delete(:nonce))} : nil
+      nonce = options.key?(:nonce) ? (%( nonce="%{nonce_value}")) % {nonce_value: ERB::Util.html_escape(options.delete(:nonce))}) : nil
       html = (options.delete(:html) || %(<div id="%{id}" style="height: %{height}; width: %{width}; text-align: center; color: #999; line-height: %{height}; font-size: 14px; font-family: 'Lucida Grande', 'Lucida Sans Unicode', Verdana, Arial, Helvetica, sans-serif;">Loading...</div>)) % {id: ERB::Util.html_escape(element_id), height: ERB::Util.html_escape(height), width: ERB::Util.html_escape(width)}
 
       createjs = "new Chartkick.#{klass}(#{element_id.to_json}, #{data_source.respond_to?(:chart_json) ? data_source.chart_json : data_source.to_json}, #{options.to_json});"

--- a/lib/chartkick/helper.rb
+++ b/lib/chartkick/helper.rb
@@ -46,8 +46,7 @@ module Chartkick
       defer = !!options.delete(:defer)
       # content_for: nil must override default
       content_for = options.key?(:content_for) ? options.delete(:content_for) : Chartkick.content_for
-      nonce = options.key?(:nonce) ? " nonce=\"#{options.delete(:nonce)}\"" : nil
-
+      nonce = (options.key?(:nonce) || %( nonce="%{nonce_value}")) % {nonce_value: ERB::Util.html_escape(options.delete(:nonce))}
       html = (options.delete(:html) || %(<div id="%{id}" style="height: %{height}; width: %{width}; text-align: center; color: #999; line-height: %{height}; font-size: 14px; font-family: 'Lucida Grande', 'Lucida Sans Unicode', Verdana, Arial, Helvetica, sans-serif;">Loading...</div>)) % {id: ERB::Util.html_escape(element_id), height: ERB::Util.html_escape(height), width: ERB::Util.html_escape(width)}
 
       createjs = "new Chartkick.#{klass}(#{element_id.to_json}, #{data_source.respond_to?(:chart_json) ? data_source.chart_json : data_source.to_json}, #{options.to_json});"

--- a/lib/chartkick/helper.rb
+++ b/lib/chartkick/helper.rb
@@ -46,13 +46,14 @@ module Chartkick
       defer = !!options.delete(:defer)
       # content_for: nil must override default
       content_for = options.key?(:content_for) ? options.delete(:content_for) : Chartkick.content_for
+      nonce = options.key?(:nonce) ? " nonce=\"#{options.delete(:nonce)}\"" : nil
 
       html = (options.delete(:html) || %(<div id="%{id}" style="height: %{height}; width: %{width}; text-align: center; color: #999; line-height: %{height}; font-size: 14px; font-family: 'Lucida Grande', 'Lucida Sans Unicode', Verdana, Arial, Helvetica, sans-serif;">Loading...</div>)) % {id: ERB::Util.html_escape(element_id), height: ERB::Util.html_escape(height), width: ERB::Util.html_escape(width)}
 
       createjs = "new Chartkick.#{klass}(#{element_id.to_json}, #{data_source.respond_to?(:chart_json) ? data_source.chart_json : data_source.to_json}, #{options.to_json});"
       if defer
         js = <<JS
-<script type="text/javascript">
+<script type="text/javascript"#{nonce}>
   (function() {
     var createChart = function() { #{createjs} };
     if (window.addEventListener) {
@@ -67,7 +68,7 @@ module Chartkick
 JS
       else
         js = <<JS
-<script type="text/javascript">
+<script type="text/javascript"#{nonce}>
   #{createjs}
 </script>
 JS

--- a/lib/chartkick/helper.rb
+++ b/lib/chartkick/helper.rb
@@ -46,7 +46,7 @@ module Chartkick
       defer = !!options.delete(:defer)
       # content_for: nil must override default
       content_for = options.key?(:content_for) ? options.delete(:content_for) : Chartkick.content_for
-      nonce = (options.key?(:nonce) || %( nonce="%{nonce_value}")) % {nonce_value: ERB::Util.html_escape(options.delete(:nonce))}
+      nonce = options.key?(:nonce) ? %( nonce="%{nonce_value}")) % {nonce_value: ERB::Util.html_escape(options.delete(:nonce))} : nil
       html = (options.delete(:html) || %(<div id="%{id}" style="height: %{height}; width: %{width}; text-align: center; color: #999; line-height: %{height}; font-size: 14px; font-family: 'Lucida Grande', 'Lucida Sans Unicode', Verdana, Arial, Helvetica, sans-serif;">Loading...</div>)) % {id: ERB::Util.html_escape(element_id), height: ERB::Util.html_escape(height), width: ERB::Util.html_escape(width)}
 
       createjs = "new Chartkick.#{klass}(#{element_id.to_json}, #{data_source.respond_to?(:chart_json) ? data_source.chart_json : data_source.to_json}, #{options.to_json});"

--- a/lib/chartkick/helper.rb
+++ b/lib/chartkick/helper.rb
@@ -46,7 +46,7 @@ module Chartkick
       defer = !!options.delete(:defer)
       # content_for: nil must override default
       content_for = options.key?(:content_for) ? options.delete(:content_for) : Chartkick.content_for
-      nonce = options.key?(:nonce) ? (%( nonce="%{nonce_value}")) % {nonce_value: ERB::Util.html_escape(options.delete(:nonce))}) : nil
+      nonce = options.key?(:nonce) ? ((%( nonce="%{nonce_value}")) % {nonce_value: ERB::Util.html_escape(options.delete(:nonce))}) : nil
       html = (options.delete(:html) || %(<div id="%{id}" style="height: %{height}; width: %{width}; text-align: center; color: #999; line-height: %{height}; font-size: 14px; font-family: 'Lucida Grande', 'Lucida Sans Unicode', Verdana, Arial, Helvetica, sans-serif;">Loading...</div>)) % {id: ERB::Util.html_escape(element_id), height: ERB::Util.html_escape(height), width: ERB::Util.html_escape(width)}
 
       createjs = "new Chartkick.#{klass}(#{element_id.to_json}, #{data_source.respond_to?(:chart_json) ? data_source.chart_json : data_source.to_json}, #{options.to_json});"


### PR DESCRIPTION
A quick addition I needed to add for my project. Perhaps a better way to do this, but I figured I'd try a PR 👍 

Example:
`<%= area_chart @player.ratings, nonce: content_security_policy_nonce(:script) %>`