### PR TITLE
Reflect change in dataSource in refreshData

### DIFF
--- a/app/assets/javascripts/chartkick.js
+++ b/app/assets/javascripts/chartkick.js
@@ -1702,10 +1702,10 @@
       fetchDataSource(chart, callback, chart.rawData);
     };
     chart.refreshData = function () {
-      if (typeof dataSource === "string") {
+      if (typeof chart.dataSource === "string") {
         // prevent browser from caching
-        var sep = dataSource.indexOf("?") === -1 ? "?" : "&";
-        var url = dataSource + sep + "_=" + (new Date()).getTime();
+        var sep = chart.dataSource.indexOf("?") === -1 ? "?" : "&";
+        var url = chart.dataSource + sep + "_=" + (new Date()).getTime();
         fetchDataSource(chart, callback, url);
       }
     };


### PR DESCRIPTION
When the dataSource was changed refreshData() would still load the old source.

Example:
```js
let chart = Chartkick.charts["chart-1"] // assume dataSource is example.org/test
chart.updateData('http://example.org/nope') // new uri - also updates dataSource
// or do chart.dataSouce = new source
chart.refreshData() // will still fetch example.org/test
```