### PR TITLE
Bugfix: Datasets are able to pass 'fill' options to adapter.

### DIFF
--- a/vendor/assets/javascripts/chartkick.js
+++ b/vendor/assets/javascripts/chartkick.js
@@ -1235,7 +1235,7 @@
             var dataset = {
               label: s.name,
               data: rows2[i],
-              fill: chartType === "area",
+              fill: s.fill === undefined ? chartType === "area" : s.fill,
               borderColor: color,
               backgroundColor: backgroundColor,
               pointBackgroundColor: color,


### PR DESCRIPTION
Just a small quick fix to be able to pass the 'fill' parameter with the data.
By doing so, one is able to e.g. fill areas between specific datasets only, cf: [Chart.js stacked datasets](http://www.chartjs.org/samples/latest/charts/area/line-datasets.html).