### PR TITLE
Added documentation for the defer option

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,12 @@ Specify legend position
 <%= line_chart data, legend: "bottom" %>
 ```
 
+Defer chart creation until after the page loads 
+
+```erb
+<%= line_chart data, defer: true %>
+```
+
 Donut chart
 
 ```erb


### PR DESCRIPTION
The defer option is a useful options for developers who want to place their application.js at the bottom of the page and not have it affect chartkick. I added a short description in the options section.