### PR TITLE
Improvement: Support Turbolinks load-events

### DIFF
--- a/lib/chartkick/helper.rb
+++ b/lib/chartkick/helper.rb
@@ -49,14 +49,17 @@ module Chartkick
       nonce = options.key?(:nonce) ? " nonce=\"#{ERB::Util.html_escape(options.delete(:nonce))}\"" : nil
       html = (options.delete(:html) || %(<div id="%{id}" style="height: %{height}; width: %{width}; text-align: center; color: #999; line-height: %{height}; font-size: 14px; font-family: 'Lucida Grande', 'Lucida Sans Unicode', Verdana, Arial, Helvetica, sans-serif;">Loading...</div>)) % {id: ERB::Util.html_escape(element_id), height: ERB::Util.html_escape(height), width: ERB::Util.html_escape(width)}
 
+      turbolinks = defined?(Turbolinks)
+      load_event_type = turbolinks ? "turbolinks:load" : "load"
+
       createjs = "new Chartkick.#{klass}(#{element_id.to_json}, #{data_source.respond_to?(:chart_json) ? data_source.chart_json : data_source.to_json}, #{options.to_json});"
-      if defer
+      if defer || turbolinks
         js = <<JS
 <script type="text/javascript"#{nonce}>
   (function() {
     var createChart = function() { #{createjs} };
     if (window.addEventListener) {
-      window.addEventListener("load", createChart, true);
+      window.addEventListener("#{load_event_type}", createChart, true);
     } else if (window.attachEvent) {
       window.attachEvent("onload", createChart);
     } else {

--- a/lib/chartkick/helper.rb
+++ b/lib/chartkick/helper.rb
@@ -59,7 +59,11 @@ module Chartkick
   (function() {
     var createChart = function() { #{createjs} };
     if (window.addEventListener) {
-      window.addEventListener("#{load_event_type}", createChart, true);
+        var createChartOnce = function() {
+          window.removeEventListener("#{load_event_type}", createChartOnce, true);
+          createChart();
+        };
+      window.addEventListener("#{load_event_type}", createChartOnce, true);
     } else if (window.attachEvent) {
       window.attachEvent("onload", createChart);
     } else {


### PR DESCRIPTION
#400 
When re-opening a page cached by turbolinks, an event of type 'turbolinks:load' is fired. However, the chartkick-helper uses the browsers event of type 'load' to initiate chart creation.

This causes the chart to:

- load only once (at the initial page-load, which is not initiated by turbolinks), when using 'defer=true' and turbolinks. This is because the event of type 'load' only fires once, and further pageloads fire events of type 'turbolinks:load'.
- load twice, when 'defer=false' and turbolinks. This is, because the cached version of the page is shown by turbolinks (starting the chart-creation script), followed by the actual page from the server (again staring the chart-creation script). This might happen unnoticed, but is problematic when using animations on charts (as the animation starts twice).



