### PR TITLE
fix Chartkick::Helper::chartkick_deep_merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ Works with Highcharts 2.1+
 
 ### Sinatra and Padrino
 
-You must include `chartkick.js` manually. [Download it here](https://raw.github.com/ankane/chartkick/master/app/assets/javascripts/chartkick.js)
+You must include `chartkick.js` manually. [Download it here](https://raw.githubusercontent.com/ankane/chartkick/master/vendor/assets/javascripts/chartkick.js)
 
 ```html
 <script src="chartkick.js"></script>

--- a/lib/chartkick/helper.rb
+++ b/lib/chartkick/helper.rb
@@ -87,9 +87,10 @@ JS
       hash_a = hash_a.dup
       hash_b.each_pair do |k, v|
         tv = hash_a[k]
-        hash_a[k] = tv.is_a?(Hash) && v.is_a?(Hash) ? tv.deep_merge(v) : v
+        hash_a[k] = tv.is_a?(Hash) && v.is_a?(Hash) ? chartkick_deep_merge(tv, v) : v
       end
       hash_a
     end
   end
 end
+

--- a/test/chartkick_test.rb
+++ b/test/chartkick_test.rb
@@ -26,4 +26,18 @@ class TestChartkick < Minitest::Test
     line_chart @data, options
     assert_equal "boom", options[:id]
   end
+
+  def test_chartkick_deep_merge_different_inner_key
+    global_option = {library: {backgroundColor: "#eee"}}
+    local_option = {library: {title: "test"}}
+    correct_merge = {library: {backgroundColor: "#eee", title: "test"}}
+    assert_equal chartkick_deep_merge(global_option, local_option), correct_merge
+  end
+
+  def test_chartkick_deep_merge_same_inner_key
+    global_option = {library: {backgroundColor: "#eee"}}
+    local_option = {library: {backgroundColor: "#fff"}}
+    correct_merge = {library: {backgroundColor: "#fff"}}
+    assert_equal chartkick_deep_merge(global_option, local_option), correct_merge
+  end
 end


### PR DESCRIPTION
I found a bug in the repository. Inside`lib/chartkick/helper.rb` file, `chartkick_deep_merge` is defined and `tv.deep_merge` is getting called.  However, `Hash#deep_merge` is undefined (this is not rails project 😄 )

So a simple fix would be calling `chartkick_deep_merge` recursively. 





