### PR TITLE
add bubble chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ Bar chart
 <%= bar_chart Shirt.group(:size).sum(:price) %>
 ```
 
+Bubble chart
+
+```erb
+<%= bubble_chart [[20, 30, 15], [40, 10, 10]] %>
+```
+
 Area chart
 
 ```erb

--- a/lib/chartkick/helper.rb
+++ b/lib/chartkick/helper.rb
@@ -19,6 +19,10 @@ module Chartkick
       chartkick_chart "BarChart", data_source, options
     end
 
+    def bubble_chart(data_source, options = {})
+      chartkick_chart "BubbleChart", data_source, options
+    end
+
     def area_chart(data_source, options = {})
       chartkick_chart "AreaChart", data_source, options
     end

--- a/test/chartkick_test.rb
+++ b/test/chartkick_test.rb
@@ -7,6 +7,7 @@ class TestChartkick < Minitest::Test
 
   def setup
     @data = [[34, 42], [56, 49]]
+    @three_d_data = [[34, 42, 56], [56, 49, 7]]
   end
 
   def test_line_chart
@@ -19,6 +20,10 @@ class TestChartkick < Minitest::Test
 
   def test_column_chart
     assert column_chart(@data)
+  end
+
+  def test_bubble_chart
+    assert bubble_chart(@three_d_data)
   end
 
   def test_options_not_mutated


### PR DESCRIPTION
It seems [chartkick.js](https://github.com/ankane/chartkick/blob/master/vendor/assets/javascripts/chartkick.js) support Bubble Chart. So I added it to the helper.  The `bubble_chart` function was also tested on my toy project and works smoothly.