### PR TITLE
Fix thousands format

### DIFF
--- a/vendor/assets/javascripts/chartkick.js
+++ b/vendor/assets/javascripts/chartkick.js
@@ -1708,7 +1708,7 @@
       var parts = value.split(".")
       value = parts[0];
       if (options.thousands) {
-        value = value.replace(/(\d)(?=(\d{3})+(?!\d))/g, options.thousands);
+        value = value.replace(/\B(?=(\d{3})+(?!\d))/g, options.thousands);
       }
       if (parts.length > 1) {
         value += (options.decimal || ".") + parts[1];


### PR DESCRIPTION
@ankane I found there exists a minor issue when formatting numbers with thousands option.

```javascript
var regexp = /(\d)(?=(\d{3})+(?!\d))/g;
console.log("1000".replace(regexp, ','));   // ,000
```

```javascript
var regexp = /\B(?=(\d{3})+(?!\d))/g;
console.log("1000".replace(regexp, ','));   // 1,000
```