### PR TITLE
Adding longitude and latitude to renderGeoChart

### DIFF
--- a/vendor/assets/javascripts/chartkick.js
+++ b/vendor/assets/javascripts/chartkick.js
@@ -2280,6 +2280,8 @@ var renderGeoChart = function renderGeoChart(chart) {
     var data = new window.google.visualization.DataTable();
     data.addColumn("string", "");
     data.addColumn("number", chart.options.label || "Value");
+    data.addColumn("number", "latitude");
+    data.addColumn("number", "longitude");
     data.addRows(chart.data);
 
     drawChart(chart, window.google.visualization.GeoChart, data, options);


### PR DESCRIPTION
I'd like to add these fields so that my team can use them from the gem itself instead of using a fork. https://github.com/Connorhd/chartkick