### PR TITLE
Add the possibility to add custom tooltips

### DIFF
--- a/vendor/assets/javascripts/chartkick.js
+++ b/vendor/assets/javascripts/chartkick.js
@@ -2241,9 +2241,21 @@ var renderBarChart = function renderBarChart(chart) {
         }
       }
     };
+    if (chart.options.customToolTip) {
+      var data = new google.visualization.DataTable()
+      data.addColumn('string')
+      data.addColumn('number')
+      // A column for custom tooltip content
+      data.addColumn({ type: 'string', role: 'tooltip' })
+      data.addRows(chart.dataSource)
+    } else {
+      var data = createDataTable(
+        chart.data,
+        'string',
+        chart.options.xtype
+      )
+    }
     var options = (0, _helpers.jsOptionsFunc)(defaultOptions, hideLegend, setTitle, setBarMin, setBarMax, setStacked, setXtitle, setYtitle)(chart, chart.options, chartOptions);
-    var data = createDataTable(chart.data, "string", chart.options.xtype);
-
     drawChart(chart, window.google.visualization.BarChart, data, options);
   });
 };


### PR DESCRIPTION
This PR will enable the possibility to add custom tooltips like this.

Normal: 
https://i.gyazo.com/1f81aa559e029afcdc5fdd233a8afbb1.png

With custom tooltips:
https://i.gyazo.com/4ef7208ec7ba132be62f9b6cd5383067.png

Reference: https://developers.google.com/chart/interactive/docs/customizing_tooltip_content#customizing-tooltip-content