### PR TITLE
Prevent exception with semi-loaded ActiveSupport.

### DIFF
--- a/lib/chartkick.rb
+++ b/lib/chartkick.rb
@@ -5,7 +5,7 @@ require "chartkick/version"
 require "chartkick/engine" if defined?(Rails)
 require "chartkick/sinatra" if defined?(Sinatra)
 
-if defined?(ActiveSupport)
+if defined?(ActiveSupport.on_load)
   ActiveSupport.on_load(:action_view) do
     include Chartkick::Helper
   end


### PR DESCRIPTION
Certain gems (eg `sinatra/contrib`) load only those parts of
ActiveSupport they require. This leads to `ActiveSupport` being defined,
but other parts (eg the `on_load`) method not.

Issue can be reproduced as follows:
```
/tmp/demo
› cat Gemfile
source 'https://rubygems.org'

gem 'sinatra-contrib', '2.0.3'
gem 'chartkick', '3.0.1'

/tmp/demo
› cat test.rb 
require 'sinatra/contrib'
require 'chartkick'

/tmp/demo
› bundle exec ruby test.rb 
Traceback (most recent call last):
	2: from test.rb:2:in `<main>'
	1: from test.rb:2:in `require'
/home/michael/.gem/ruby/2.5.0/gems/chartkick-3.0.1/lib/chartkick.rb:9:in `<top (required)>': undefined method `on_load' for ActiveSupport:Module (NoMethodError)
```