### PR TITLE
Added support for manual_load: true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 3.0.2 [unreleased]
 
 - Fixed error with `nonce` option with Secure Headers and Rails < 5.2
+- Add support for `manual_load: true`
 
 ## 3.0.1
 

--- a/README.md
+++ b/README.md
@@ -176,6 +176,13 @@ Defer chart creation until after the page loads
 <%= line_chart data, defer: true %>
 ```
 
+Chart creation needs to be triggered manually. This option overrules `defer`
+```erb
+<%= line_chart data, manual_load: true, id: 'my-chart' %>
+
+<%# then in JS: document.getElementById('my-chart').dispatchEvent(new Event('load')); %>
+```
+
 Donut chart
 
 ```erb


### PR DESCRIPTION
👋 Hello Chartkick, this PR adds support for a new option, `manual_load`. It allows delaying the creation of the chart until explicitly triggered by the client.

This makes it possible to trigger the creation of the chart, which can be an expensive operation, when a user clicks on a "Load" button. Or, and this is my use case, when the chart enters the viewport when scrolling down, in order to avoid heavy computations of charts that are not visible.

What do you think?