### PR TITLE
Added support for class option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 3.0.2 [unreleased]
 
 - Fixed error with `nonce` option with Secure Headers and Rails < 5.2
+- Add support for class option
 
 ## 3.0.1
 

--- a/README.md
+++ b/README.md
@@ -102,10 +102,10 @@ render json: Task.group(:goal_id).group_by_day(:completed_at).count.chart_json
 
 ### Options
 
-Id, width, and height
+Id, class, width, and height
 
 ```erb
-<%= line_chart data, id: "users-chart", width: "800px", height: "500px" %>
+<%= line_chart data, id: "users-chart", class: "my-app-chart", width: "800px", height: "500px" %>
 ```
 
 Min and max values

--- a/lib/chartkick/helper.rb
+++ b/lib/chartkick/helper.rb
@@ -41,6 +41,7 @@ module Chartkick
       @chartkick_chart_id ||= 0
       options = chartkick_deep_merge(Chartkick.options, options)
       element_id = options.delete(:id) || "chart-#{@chartkick_chart_id += 1}"
+      element_class = options.delete(:class) || "chart-chartkick"
       height = options.delete(:height) || "300px"
       width = options.delete(:width) || "100%"
       defer = !!options.delete(:defer)
@@ -61,7 +62,7 @@ module Chartkick
       end
       nonce_html = nonce ? " nonce=\"#{ERB::Util.html_escape(nonce)}\"" : nil
 
-      html = (options.delete(:html) || %(<div id="%{id}" style="height: %{height}; width: %{width}; text-align: center; color: #999; line-height: %{height}; font-size: 14px; font-family: 'Lucida Grande', 'Lucida Sans Unicode', Verdana, Arial, Helvetica, sans-serif;">Loading...</div>)) % {id: ERB::Util.html_escape(element_id), height: ERB::Util.html_escape(height), width: ERB::Util.html_escape(width)}
+      html = (options.delete(:html) || %(<div id="%{id}" class="%{class}" style="height: %{height}; width: %{width}; text-align: center; color: #999; line-height: %{height}; font-size: 14px; font-family: 'Lucida Grande', 'Lucida Sans Unicode', Verdana, Arial, Helvetica, sans-serif;">Loading...</div>)) % {id: ERB::Util.html_escape(element_id), class: ERB::Util.html_escape(element_class), height: ERB::Util.html_escape(height), width: ERB::Util.html_escape(width)}
 
       createjs = "new Chartkick.#{klass}(#{element_id.to_json}, #{data_source.respond_to?(:chart_json) ? data_source.chart_json : data_source.to_json}, #{options.to_json});"
       if defer


### PR DESCRIPTION
👋 Hello Chartkick, this PR is a small addition that allows specifying the class of the HTML element.

In [my use case](https://github.com/ankane/chartkick/pull/453), I need to be able to detect all Chartkick elements before they are loaded, i.e. before their chart is created via `createChart`, so `Chartkick.charts` is not an option. Adding a class allows that.

What do you think?