### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ In `application.js`, add:
 //= require chartkick
 ```
 
-This sets up Chartkick with Chart.js. For other charting libaries, see [detailed instructions](#installation).
+This sets up Chartkick with Chart.js. For other charting libraries, see [detailed instructions](#installation).
 
 ## Charts
 


### PR DESCRIPTION
Fix a little typo in the README: `libaries` => `libraries` 🎈 