### PR TITLE
Add a support to google chart(line and bars) annotations

### DIFF
--- a/lib/chartkick/version.rb
+++ b/lib/chartkick/version.rb
@@ -1,3 +1,3 @@
 module Chartkick
-  VERSION = "3.0.2"
+  VERSION = "3.0.3"
 end


### PR DESCRIPTION
This feature add a way to use annotations in google chart(line and bars).
First of all i need to pass chart object to `createDataTable()` function because before was just `data`, now i need to access some objects like `series` and `rawData` to make some verifications.

I verify if chart has `annotations` key to add a new column and add the respective value that will showed in graph.

I need this feature with urgency because this i did not contemplate other charts but i'm available to help any that need help with this.

Releted: #80 