### PR TITLE
Updated Readme File for Trailblazer Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ For Rails 5 / Sprockets, in `app/assets/javascripts/application.js`, add:
 //= require Chart.bundle
 ```
 
+For Integration with Trailblazer, in the trailblazer cells include:
+
+```ruby
+include Chartkick::Helper
+```
+
 This sets up Chartkick with Chart.js. For other charting libraries, see [detailed instructions](#installation).
 
 ## Charts


### PR DESCRIPTION
While integration of chatkick with trailblazer the methods like line_chart, pie_chart were not accessible in while rendering the trailblazer cells. Got following error:

undefined method `column_chart' for #<User::Cell::Report:0x00007fa72ec9ecf8>

By including the Chartkick::Helper in trailblazer cell the problem got solved.