### PR TITLE
Improvement: Support Turbolinks load-events

### DIFF
--- a/lib/chartkick/helper.rb
+++ b/lib/chartkick/helper.rb
@@ -84,13 +84,23 @@ module Chartkick
       end
       createjs = "new Chartkick[%{type}](%{id}, %{data}, %{options});" % js_vars
 
-      if defer
+      turbolinks = defined?(Turbolinks)
+
+      load_event_type = turbolinks ? "turbolinks:load" : "load"
+
+
+      if defer || turbolinks
         js = <<JS
 <script type="text/javascript"#{nonce_html}>
   (function() {
     var createChart = function() { #{createjs} };
     if (window.addEventListener) {
-      window.addEventListener("load", createChart, true);
+      
+      var createChartOnce = function() {
+        window.removeEventListener("#{load_event_type}", createChartOnce, true);
+        createChart();
+      };
+      window.addEventListener("#{load_event_type}", createChartOnce, true);
     } else if (window.attachEvent) {
       window.attachEvent("onload", createChart);
     } else {


### PR DESCRIPTION
This resurrects https://github.com/ankane/chartkick/pull/409 from @thijsre since we just experienced the same issues. 

In your tests @ankane you might not have had this problem if turbolinks was loaded in the document `head` in a way that blocked js on the page. If instead best practices are followed, and js execution is deferred until after the page is loaded then the chartkick js also must be deferred. Otherwise, the inline js would raise because Chartkick js has not yet been loaded when the inline script tag is evaluated. 

In this situation, while consistently defering js execution, and using turbolinks, we must use the turbolinks load event, since on turbolinks load the `load` event currently being listened to does not fire. 

I can imagine changing this to take an argument to get the turbolinks behavior instead of detecting the gem's presence, but this happens to work for us since we consistently use turbolinks throughout the application. 

