### PR TITLE
increasing the hit radius seems like an easy win

### DIFF
--- a/vendor/assets/javascripts/Chart.bundle.js
+++ b/vendor/assets/javascripts/Chart.bundle.js
@@ -4437,7 +4437,7 @@ core_defaults._set('global', {
 			borderColor: defaultColor$1,
 			borderWidth: 1,
 			// Hover
-			hitRadius: 1,
+			hitRadius: 100,
 			hoverRadius: 4,
 			hoverBorderWidth: 1
 		}


### PR DESCRIPTION
I had a look at this open issue: https://github.com/ankane/chartkick/issues/525

Why not just increase the value of the `hitRadius`? It makes viewing the tooltip much easier, and doesn't seem to have any negative effects, like preventing sibling tooltips from appearing...

![Chartkick_Hover](https://user-images.githubusercontent.com/355634/77839677-9bd63900-7133-11ea-9d79-e979142dbdaa.gif)
