### PR TITLE
Fix turbolinks loading twice

### DIFF
--- a/lib/chartkick/helper.rb
+++ b/lib/chartkick/helper.rb
@@ -91,13 +91,16 @@ module Chartkick
   (function() {
     var createChart = function() {
       #{createjs}
-      window.removeEventListener("turbolinks:load", createChart, true);
+      document.removeEventListener("turbolinks:load", createChart, true);
     };
-    if (document.documentElement.hasAttribute("data-turbolinks-preview")) {
-      createChart();
-    } else {
-      window.addEventListener("turbolinks:load", createChart, true);
+    var cleanupBeforeCache = function() {
+      Chartkick.eachChart( function(chart) {
+        chart.destroy();
+      });
+      document.removeEventListener("turbolinks:before-cache", cleanupBeforeCache, true);
     }
+    document.addEventListener("turbolinks:load", createChart, true);
+    document.addEventListener("turbolinks:before-cache", cleanupBeforeCache, true);
   })();
 </script>
 JS

--- a/lib/chartkick/helper.rb
+++ b/lib/chartkick/helper.rb
@@ -91,13 +91,11 @@ module Chartkick
   (function() {
     var createChart = function() {
       #{createjs}
-      window.removeEventListener("load", createChart, true);
       window.removeEventListener("turbolinks:load", createChart, true);
     };
     if (document.documentElement.hasAttribute("data-turbolinks-preview")) {
       createChart();
     } else {
-      window.addEventListener("load", createChart, true);
       window.addEventListener("turbolinks:load", createChart, true);
     }
   })();


### PR DESCRIPTION
On #536 you asked me to test the `defert_turbolinks` branch.

It _kinda_ worked, but I noticed a flickering behavior on (it's very noticeable when you have something like `library: { animation: { easing: 'easeOutQuad' }`).

I'm not an expert on turbolinks, but have been working with it for quite a while, so I noticed the following on the code:

1. It was adding two event listeners, one on `load` and another one on `turbolinks:load`. That redundancy is not necessary and it was invoking the createChart function twice, since turbolinks always fires `turbolinks:load` on every document.ready, regardless if it's a first time visit or a visit due to an internal link click or a restoration visit (back browser button). 

Maybe you added both because it didn't work like this on previous turbolinks versions (you had to listen for both events), but on Turbolinks 5 it works like this. Check out https://github.com/turbolinks/turbolinks#observing-navigation-events , where it states `The most significant of these is the turbolinks:load event, which fires once on the initial page load, and again after every Turbolinks visit.`

2. It was not cleaning up after itself. So I added a `document.addEventListener("turbolinks:before-cache", cleanupBeforeCache)` handler, which invokes `chart.destroy()`. This way the page is cached without the graphs already loaded, which I think should be the way to go, because it prevents the flickering behavior, memory leaks and the display of stale graph data even for a split second (Chartkick is very fast to load, I'd call it instant, so I don't think we're losing anything here).

This pull request has been tested on (1) visiting the graph pages directly and reloading them (so, first visit is on the page that contains Chartkick), (2) visiting the graph pages by loading a different page and then clicking on a link to load the page via turbolinks and (3) going back to the page with the graphs by using the back browser button (restoration visit), and it's working on all 3 scenarios :)