### PR TITLE
Correct script type attribute

### DIFF
--- a/lib/chartkick/helper.rb
+++ b/lib/chartkick/helper.rb
@@ -86,7 +86,7 @@ module Chartkick
 
       if defer
         js = <<JS
-<script type="text/javascript"#{nonce_html}>
+<script type="application/javascript"#{nonce_html}>
   (function() {
     var createChart = function() { #{createjs} };
     if (window.addEventListener) {
@@ -101,7 +101,7 @@ module Chartkick
 JS
       else
         js = <<JS
-<script type="text/javascript"#{nonce_html}>
+<script type="application/javascript"#{nonce_html}>
   #{createjs}
 </script>
 JS


### PR DESCRIPTION
This is a very very small PR, just to correct the `type` attribute of the `script` tags.
I'm currently working on a vue application, which doesn't allow script tags in the DOM unless they have the correct signature (that is `application/javascript`), and this is the main reason of the PR.
Other that that, I still think that it would be better to correct them anyways, since the actual MIME type is `application/javascript`...