### PR TITLE
Make the donut charts cutoutPercentage configurable

### DIFF
--- a/vendor/assets/javascripts/chartkick.js
+++ b/vendor/assets/javascripts/chartkick.js
@@ -875,7 +875,7 @@
   defaultExport.prototype.renderPieChart = function renderPieChart (chart) {
     var options = merge({}, baseOptions);
     if (chart.options.donut) {
-      options.cutoutPercentage = 50;
+      options.cutoutPercentage = chart.options.cutoutPercentage || 50;
     }
 
     if ("legend" in chart.options) {


### PR DESCRIPTION
Makes the donut cutout percentage configurable.

Related issue: https://github.com/ankane/chartkick/issues/544

cc:// @ankane 