### PR TITLE
Add removeEvent function

### DIFF
--- a/vendor/assets/javascripts/chartkick.js
+++ b/vendor/assets/javascripts/chartkick.js
@@ -1881,6 +1881,14 @@
     }
   }
 
+  function removeEvent(elem, event, fn) {
+    if (elem.removeEventListener) {
+      elem.removeEventListener(event, fn, false);
+    } else {
+      elem.detachEvent("on" + event, fn);
+    }
+  }
+
   // https://gist.github.com/shawnbot/4166283
   function childOf(p, c) {
     if (p === c) { return false; }


### PR DESCRIPTION
**Problem:**
when trying to destroy the chart getting the next error:
```
chartkick.js:2382 Uncaught ReferenceError: removeEvent is not defined
    at LineChart.destroy (chartkick.js:2382)
    at <anonymous>:1:7
```

**Solution:**
Add `removeEvent` from chartkick.js
https://github.com/ankane/chartkick.js/blob/7847df2131b7c2abb26443c6d67641ac7899f88b/src/download.js#L66
