### PR TITLE
Handle turbolinks renamed to turbo

### DIFF
--- a/lib/chartkick/helper.rb
+++ b/lib/chartkick/helper.rb
@@ -117,6 +117,7 @@ module Chartkick
         <script#{nonce_html}>
           (function() {
             if (document.documentElement.hasAttribute("data-turbolinks-preview")) return;
+            if (document.documentElement.hasAttribute("data-turbo-preview")) return;
 
             var createChart = function() { #{createjs} };
             if ("Chartkick" in window) {

--- a/vendor/assets/javascripts/chartkick.js
+++ b/vendor/assets/javascripts/chartkick.js
@@ -2491,6 +2491,9 @@
     document.addEventListener("turbolinks:before-render", function() {
       Chartkick.destroyAll();
     });
+    document.addEventListener("turbo:before-render", function() {
+      Chartkick.destroyAll();
+    });
 
     // use setTimeout so charting library can come later in same JS file
     setTimeout(function() {


### PR DESCRIPTION
[Turbolinks](https://github.com/turbolinks/turbolinks) is now [Turbo](https://github.com/hotwired/turbo). Attribute and event names have changed `turbolinks -> turbo`. This PR remains backwards-compatible with the old names, but adds compatibility for the new names as well.
