### PR TITLE
add donut_chart as separate chart helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,11 @@ Donut chart
 <%= pie_chart data, donut: true %>
 ```
 
+or use the shorthand
+```erb
+<%= donut_chart data %>
+```
+
 Prefix, useful for currency - *Chart.js, Highcharts*
 
 ```erb

--- a/lib/chartkick/helper.rb
+++ b/lib/chartkick/helper.rb
@@ -11,6 +11,10 @@ module Chartkick
       chartkick_chart "PieChart", data_source, **options
     end
 
+    def donut_chart(data_source, **options)
+      chartkick_chart "PieChart", data_source, **options.merge({donut: true})
+    end
+
     def column_chart(data_source, **options)
       chartkick_chart "ColumnChart", data_source, **options
     end

--- a/test/chartkick_test.rb
+++ b/test/chartkick_test.rb
@@ -16,6 +16,10 @@ class ChartkickTest < Minitest::Test
     assert_chart pie_chart(@data)
   end
 
+  def test_donut_chart
+    assert_chart donut_chart(@data)
+  end
+
   def test_column_chart
     assert_chart column_chart(@data)
   end


### PR DESCRIPTION
For donut chart loving people, it is a more descriptive line of code to call `donut_chart data` instead of `pie_chart data, donut: true`.

This PR adds a `donut_chart` helper as shorthand.  