### PR TITLE
Add unpoly support

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,11 @@ Donut chart
 <%= pie_chart data, donut: true %>
 ```
 
+or use the shorthand
+```erb
+<%= donut_chart data %>
+```
+
 Prefix, useful for currency - *Chart.js, Highcharts*
 
 ```erb

--- a/lib/chartkick/helper.rb
+++ b/lib/chartkick/helper.rb
@@ -11,6 +11,10 @@ module Chartkick
       chartkick_chart "PieChart", data_source, **options
     end
 
+    def donut_chart(data_source, **options)
+      chartkick_chart "PieChart", data_source, **options.merge({donut: true})
+    end
+
     def column_chart(data_source, **options)
       chartkick_chart "ColumnChart", data_source, **options
     end

--- a/test/chartkick_test.rb
+++ b/test/chartkick_test.rb
@@ -44,6 +44,14 @@ class ChartkickTest < Minitest::Test
     assert_chart timeline(@data)
   end
 
+  def test_unpoly_line_chart
+    assert_unpoly_chart line_chart(@data, unpoly: true)
+  end
+
+  def test_unpoly_with_custom_class
+    assert_unpoly_chart line_chart(@data, unpoly: 'custom-class'), 'custom-class'
+  end
+
   def test_escape_data
     bad_data = "</script><script>alert('xss')</script>"
     assert_includes column_chart(bad_data), "\\u003cscript\\u003e"
@@ -186,6 +194,10 @@ class ChartkickTest < Minitest::Test
 
   def assert_chart(chart)
     assert_match "new Chartkick", chart
+  end
+
+  def assert_unpoly_chart(chart, css_class='chartkick-chart')
+    assert_match '<div class="' + css_class + '"', chart
   end
 
   def content_for(value)

--- a/test/chartkick_test.rb
+++ b/test/chartkick_test.rb
@@ -16,6 +16,10 @@ class ChartkickTest < Minitest::Test
     assert_chart pie_chart(@data)
   end
 
+  def test_donut_chart
+    assert_chart donut_chart(@data)
+  end
+
   def test_column_chart
     assert_chart column_chart(@data)
   end


### PR DESCRIPTION
I use a lot the [Unpoly](https://unpoly.com/) gem, which allows us to run custom javascript without inline script tags.
This commit adds the ability to render the data and options as html attributes to a div instead of an inline script.

But there is a caveat. When using unpoly, we need to add js code as a so called 'unpoly compiler'. This js code needs to be shipped with webpack or the asset pipeline on page load.

I added this code to the readme, but I'm not sure, if this is the best way to add this feature. Maybe there is a more elegant way to include the unpoly compiler. 

I successfully tested this feature (code) as a monkey patch in one of my projects and would love to have it in the main gem.