### PR TITLE
Fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,7 +447,7 @@ gem "chartkick"
 
 Next, choose your charting library.
 
-- [Chart.js](#chart-js)
+- [Chart.js](#chartjs)
 - [Google Charts](#google-charts)
 - [Highcharts](#highcharts)
 


### PR DESCRIPTION
The installation link to Chart.js is broken.

To reproduce
Got to the installation section https://github.com/ankane/chartkick#installation
See that the chart js link is broken
See that the chart js installation section does not have a hyphen