### PR TITLE
Update helper to include nonce in a ViewComponent context

### DIFF
--- a/lib/chartkick/helper.rb
+++ b/lib/chartkick/helper.rb
@@ -1,5 +1,6 @@
 require "json"
 require "erb"
+require 'securerandom'
 
 module Chartkick
   module Helper

--- a/lib/chartkick/helper.rb
+++ b/lib/chartkick/helper.rb
@@ -62,6 +62,9 @@ module Chartkick
         elsif respond_to?(:content_security_policy_script_nonce)
           # Secure Headers
           nonce = content_security_policy_script_nonce
+        elsif respond_to?(:helpers) && helpers.respond_to?(:content_security_policy_nonce)
+          # ViewComponent render context
+          nonce = helpers.content_security_policy_nonce
         else
           nonce = nil
         end

--- a/lib/chartkick/helper.rb
+++ b/lib/chartkick/helper.rb
@@ -41,9 +41,7 @@ module Chartkick
     def chartkick_chart(klass, data_source, **options)
       options = chartkick_deep_merge(Chartkick.options, options)
 
-      @chartkick_chart_id ||= 0
-      element_id = options.delete(:id) || "chart-#{@chartkick_chart_id += 1}"
-
+      element_id = options.delete(:id) || "chart-#{SecureRandom.hex(8)}"
       height = (options.delete(:height) || "300px").to_s
       width = (options.delete(:width) || "100%").to_s
       defer = !!options.delete(:defer)

--- a/test/chartkick_test.rb
+++ b/test/chartkick_test.rb
@@ -167,11 +167,13 @@ class ChartkickTest < Minitest::Test
     Chartkick.options = {}
   end
 
-  def test_chart_ids
-    @chartkick_chart_id = 0
-    3.times do |i|
-      assert_match "chart-#{i + 1}", line_chart(@data)
+  def test_chart_ids_dont_collide
+    outputs = 3.times.map do
+      html = line_chart(@data)
+      html.match(/id="(chart-[-\w]{16})"/)[1]
     end
+
+    assert_equal outputs.uniq.length, outputs.length
   end
 
   def test_chart_json


### PR DESCRIPTION
Hi @ankane,

When wrapping Chartkick with [ViewComponent](https://viewcomponent.org), the helper wasn't able to determine the availability of the `content_security_policy_nonce` and so it wasn't including it. This was leading to CSP violations due to a bare `<script>` tag when a chart was rendered inside a ViewComponent.

ViewComponent puts all the normally available ActionView/Rails helpers [on a local `helpers` proxy object](https://viewcomponent.org/guide/helpers.html#proxy) when rendering, so the existing check was returning false.

This change adds an additional check in the Chartkick helper to check for ViewComponent context after all others have been checked.

About testing, I didn't want to add a ton of additional test code for such a simple addition, but open to suggestions.

Thanks for Chartkick!
