### PR TITLE
Provide a 'Changelog' link on rubygems.org/gems/chartkick

### DIFF
--- a/chartkick.gemspec
+++ b/chartkick.gemspec
@@ -14,4 +14,6 @@ Gem::Specification.new do |spec|
   spec.require_path  = "lib"
 
   spec.required_ruby_version = ">= 2.7"
+
+  spec.metadata["changelog_uri"] = "https://github.com/ankane/chartkick/blob/master/CHANGELOG.md"
 end


### PR DESCRIPTION
By providing a 'changelog_uri' in the metadata of the gemspec a 'Changelog' link will be shown on https://rubygems.org/gems/chartkick which makes it quick and easy for someone to check on the changes introduced with a new version.

Details of this functionality can be found on https://guides.rubygems.org/specification-reference/
